### PR TITLE
Board Export to CSV/MD, Added Vite Test, Simplified Login

### DIFF
--- a/app/components/BoardToolbar.tsx
+++ b/app/components/BoardToolbar.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import TimerButton from "./TimerButton";
+import ExportButton from "./ExportButton";
 import Button from "./Button";
 import { useBoard } from "~/context/BoardContext";
 import { EditIcon, PlusIcon } from "~/images/icons";
@@ -62,6 +63,7 @@ export default function BoardToolbar({ title }: { title: string }) {
         <TimerDisplay />
       </div>
       <TimerButton />
+      <ExportButton />
       <Button
         icon={<PlusIcon />}
         text="Column"

--- a/app/components/ExportButton.tsx
+++ b/app/components/ExportButton.tsx
@@ -1,0 +1,83 @@
+import { useState, useRef, useEffect } from "react";
+import { useBoard } from "~/context/BoardContext";
+import { DownloadIcon, TableIcon, DocumentIcon } from "~/images/icons";
+import { exportToCSV, exportToMarkdown, downloadFile } from "~/utils/exportBoard";
+import Button from "./Button";
+
+export default function ExportButton() {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const { title, columns } = useBoard();
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        open &&
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  useEffect(() => {
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        setOpen(false);
+        buttonRef.current?.focus();
+      }
+    }
+
+    document.addEventListener("keydown", handleEsc);
+    return () => document.removeEventListener("keydown", handleEsc);
+  }, []);
+
+  function handleExportCSV() {
+    const csv = exportToCSV(title, columns);
+    downloadFile(csv, `${title}.csv`, "text/csv");
+    setOpen(false);
+  }
+
+  function handleExportMarkdown() {
+    const md = exportToMarkdown(title, columns);
+    downloadFile(md, `${title}.md`, "text/markdown");
+    setOpen(false);
+  }
+
+  return (
+    <div ref={containerRef}>
+      <Button
+        ref={buttonRef}
+        onClick={() => setOpen(!open)}
+        icon={<DownloadIcon />}
+        text="Export"
+        aria-expanded={open}
+        aria-haspopup="menu"
+      />
+
+      {open && (
+        <div className="absolute mt-2 bg-white dark:bg-slate-800 rounded shadow-xl/30 p-2 flex flex-col gap-2 w-[180px] -translate-x-1/4 transform text-center border border-slate-400 dark:border-slate-700">
+          <Button
+            onClick={handleExportCSV}
+            variant="text"
+            icon={<TableIcon />}
+            text="Export CSV"
+            className="w-full justify-start"
+          />
+          <Button
+            onClick={handleExportMarkdown}
+            variant="text"
+            icon={<DocumentIcon />}
+            text="Export Markdown"
+            className="w-full justify-start"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/images/icons.tsx
+++ b/app/images/icons.tsx
@@ -497,6 +497,67 @@ export function CheckIcon({ size = 'md', className = '' }: IconProps) {
   );
 }
 
+export function TableIcon({ size = 'md', className = '' }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      xmlns="http://www.w3.org/2000/svg"
+      className={`${sizeMap[size]} ${className}`}
+    >
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <line x1="3" y1="9" x2="21" y2="9" />
+      <line x1="3" y1="15" x2="21" y2="15" />
+      <line x1="9" y1="3" x2="9" y2="21" />
+      <line x1="15" y1="3" x2="15" y2="21" />
+    </svg>
+  );
+}
+
+export function DocumentIcon({ size = 'md', className = '' }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      xmlns="http://www.w3.org/2000/svg"
+      className={`${sizeMap[size]} ${className}`}
+    >
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <polyline points="14 2 14 8 20 8" />
+      <line x1="16" y1="13" x2="8" y2="13" />
+      <line x1="16" y1="17" x2="8" y2="17" />
+      <line x1="10" y1="9" x2="8" y2="9" />
+    </svg>
+  );
+}
+
+export function DownloadIcon({ size = 'md', className = '' }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      xmlns="http://www.w3.org/2000/svg"
+      className={`${sizeMap[size]} ${className}`}
+    >
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" y1="15" x2="12" y2="3" />
+    </svg>
+  );
+}
+
 export function CloseIcon({ size = 'md', className = '' }: IconProps) {
   return (
     <svg

--- a/app/routes/auth/callback.test.ts
+++ b/app/routes/auth/callback.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Track session data across mock calls
+let sessionData: Record<string, string> = {};
+
+vi.mock("~/session.server", () => ({
+  getSession: vi.fn(async () => ({
+    get: (key: string) => sessionData[key],
+    set: (key: string, value: string) => { sessionData[key] = value; },
+    unset: (key: string) => { delete sessionData[key]; },
+  })),
+  commitSession: vi.fn(async () => "session-cookie-value"),
+}));
+
+const mockQuery = vi.fn();
+const mockRelease = vi.fn();
+vi.mock("~/server/db_config", () => ({
+  pool: {
+    connect: vi.fn(async () => ({
+      query: mockQuery,
+      release: mockRelease,
+    })),
+  },
+}));
+
+// Mock global fetch for token and profile requests
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function makeState(returnTo: string | null = "/app/dashboard") {
+  return Buffer.from(JSON.stringify({ returnTo, nonce: "test-nonce" })).toString("base64url");
+}
+
+function setupFetchMocks() {
+  mockFetch
+    .mockResolvedValueOnce({
+      json: async () => ({ access_token: "test-access-token" }),
+    })
+    .mockResolvedValueOnce({
+      json: async () => ({
+        sub: "ext-123",
+        email: "test@example.com",
+        name: "Test User",
+        preferred_username: "testuser",
+        given_name: "Test",
+        family_name: "User",
+        email_verified: true,
+      }),
+    });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessionData = {};
+
+  process.env.OAUTH_TOKEN_URL = "https://auth.example.com/token";
+  process.env.OAUTH_REDIRECT_URI = "http://localhost:3000/auth/callback";
+  process.env.OAUTH_CLIENT_ID = "test-client-id";
+  process.env.OAUTH_CLIENT_SECRET = "test-client-secret";
+  process.env.OAUTH_USERINFO_URL = "https://auth.example.com/userinfo";
+  process.env.SESSION_SECRET = "test-secret";
+
+  mockQuery.mockResolvedValue({ rows: [{ id: 42 }] });
+});
+
+describe("GET /auth/callback", () => {
+  it("returns 400 when code is missing", async () => {
+    const { loader } = await import("./callback");
+    const state = makeState();
+    const request = new Request(`http://localhost:3000/auth/callback?state=${state}`);
+
+    try {
+      await loader({ request });
+      expect.unreachable("should have thrown");
+    } catch (response: unknown) {
+      const res = response as Response;
+      expect(res.status).toBe(400);
+      expect(await res.text()).toBe("Missing code or state");
+    }
+  });
+
+  it("returns 400 when state is missing", async () => {
+    const { loader } = await import("./callback");
+    const request = new Request("http://localhost:3000/auth/callback?code=test-code");
+
+    try {
+      await loader({ request });
+      expect.unreachable("should have thrown");
+    } catch (response: unknown) {
+      const res = response as Response;
+      expect(res.status).toBe(400);
+      expect(await res.text()).toBe("Missing code or state");
+    }
+  });
+
+  it("redirects to / when session state is already cleared (duplicate callback)", async () => {
+    const { loader } = await import("./callback");
+    const state = makeState();
+    // Don't set oauth_state in session — simulates already-completed OAuth
+    const request = new Request(`http://localhost:3000/auth/callback?code=test-code&state=${state}`);
+
+    const res = await loader({ request }) as unknown as Response;
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/");
+  });
+
+  it("returns 400 when state does not match session", async () => {
+    const { loader } = await import("./callback");
+    const state = makeState();
+    sessionData["oauth_state"] = "different-state";
+    const request = new Request(`http://localhost:3000/auth/callback?code=test-code&state=${state}`);
+
+    try {
+      await loader({ request });
+      expect.unreachable("should have thrown");
+    } catch (response: unknown) {
+      const res = response as Response;
+      expect(res.status).toBe(400);
+      expect(await res.text()).toBe("Invalid OAuth state");
+    }
+  });
+
+  it("exchanges code for token and upserts user on success", async () => {
+    setupFetchMocks();
+    const { loader } = await import("./callback");
+    const state = makeState("/app/dashboard");
+    sessionData["oauth_state"] = state;
+    const request = new Request(`http://localhost:3000/auth/callback?code=test-code&state=${state}`);
+
+    const res = await loader({ request }) as unknown as Response;
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/app/dashboard");
+    expect(res.headers.get("Set-Cookie")).toBe("session-cookie-value");
+
+    // Verify token exchange
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://auth.example.com/token",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      }),
+    );
+
+    // Verify user profile fetch
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://auth.example.com/userinfo",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer test-access-token" },
+      }),
+    );
+
+    // Verify DB upsert was called
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO users"),
+      ["ext-123", "test@example.com", "Test User", "testuser", "Test", "User", true],
+    );
+
+    // Verify session was updated with user ID
+    expect(sessionData["userId"]).toBe(42);
+
+    // Verify DB client was released
+    expect(mockRelease).toHaveBeenCalled();
+  });
+
+  it("redirects to /app/dashboard when returnTo is null", async () => {
+    setupFetchMocks();
+    const { loader } = await import("./callback");
+    const state = makeState(null);
+    sessionData["oauth_state"] = state;
+    const request = new Request(`http://localhost:3000/auth/callback?code=test-code&state=${state}`);
+
+    const res = await loader({ request }) as unknown as Response;
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/app/dashboard");
+  });
+
+  it("releases the DB client even when the query fails", async () => {
+    setupFetchMocks();
+    const { loader } = await import("./callback");
+    const state = makeState();
+    sessionData["oauth_state"] = state;
+    mockQuery.mockRejectedValueOnce(new Error("DB error"));
+
+    const request = new Request(`http://localhost:3000/auth/callback?code=test-code&state=${state}`);
+
+    await expect(loader({ request })).rejects.toThrow("DB error");
+    expect(mockRelease).toHaveBeenCalled();
+  });
+});

--- a/app/routes/auth/login.test.ts
+++ b/app/routes/auth/login.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("~/session.server", () => ({
+  getSession: vi.fn(async () => {
+    const data: Record<string, string> = {};
+    return {
+      get: (key: string) => data[key],
+      set: (key: string, value: string) => { data[key] = value; },
+      unset: (key: string) => { delete data[key]; },
+      data,
+    };
+  }),
+  commitSession: vi.fn(async () => "session-cookie-value"),
+}));
+
+beforeEach(() => {
+  process.env.OAUTH_CLIENT_ID = "test-client-id";
+  process.env.OAUTH_REDIRECT_URI = "http://localhost:3000/auth/callback";
+  process.env.OAUTH_SCOPES = "openid profile email";
+  process.env.OAUTH_AUTHORIZATION_URL = "https://auth.example.com/authorize";
+  process.env.SESSION_SECRET = "test-secret";
+});
+
+describe("GET /auth/login", () => {
+  it("redirects to the OAuth authorization URL with correct params", async () => {
+    const { loader } = await import("./login");
+    const request = new Request("http://localhost:3000/auth/login?returnTo=/app/dashboard");
+
+    const res = await loader({ request }) as unknown as Response;
+    expect(res.status).toBe(302);
+
+    const location = res.headers.get("Location")!;
+    expect(location).toContain("https://auth.example.com/authorize");
+
+    const redirectUrl = new URL(location);
+    expect(redirectUrl.searchParams.get("response_type")).toBe("code");
+    expect(redirectUrl.searchParams.get("client_id")).toBe("test-client-id");
+    expect(redirectUrl.searchParams.get("redirect_uri")).toBe("http://localhost:3000/auth/callback");
+    expect(redirectUrl.searchParams.get("scope")).toBe("openid profile email");
+  });
+
+  it("encodes returnTo in the state parameter", async () => {
+    const { loader } = await import("./login");
+    const request = new Request("http://localhost:3000/auth/login?returnTo=/app/board/123");
+
+    const res = await loader({ request }) as unknown as Response;
+    const location = res.headers.get("Location")!;
+    const redirectUrl = new URL(location);
+    const state = redirectUrl.searchParams.get("state")!;
+    const decoded = JSON.parse(Buffer.from(state, "base64url").toString("utf-8"));
+    expect(decoded.returnTo).toBe("/app/board/123");
+    expect(decoded.nonce).toBeDefined();
+  });
+
+  it("sets the session cookie in the response", async () => {
+    const { loader } = await import("./login");
+    const request = new Request("http://localhost:3000/auth/login");
+
+    const res = await loader({ request }) as unknown as Response;
+    expect(res.headers.get("Set-Cookie")).toBe("session-cookie-value");
+  });
+});

--- a/app/routes/auth/logout.test.ts
+++ b/app/routes/auth/logout.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("~/session.server", () => ({
+  getSession: vi.fn(async () => ({
+    get: vi.fn(),
+    set: vi.fn(),
+  })),
+  destroySession: vi.fn(async () => "destroyed-cookie-value"),
+}));
+
+beforeEach(() => {
+  delete process.env.LOGOUT_REDIRECT_URL;
+});
+
+describe("GET /auth/logout", () => {
+  it("destroys the session and redirects to /", async () => {
+    const { loader } = await import("./logout");
+    const request = new Request("http://localhost:3000/auth/logout");
+
+    const res = await loader({ request }) as unknown as Response;
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/");
+    expect(res.headers.get("Set-Cookie")).toBe("destroyed-cookie-value");
+  });
+
+  it("redirects to LOGOUT_REDIRECT_URL when set", async () => {
+    process.env.LOGOUT_REDIRECT_URL = "https://auth.example.com/logout";
+    const { loader } = await import("./logout");
+    const request = new Request("http://localhost:3000/auth/logout");
+
+    const res = await loader({ request }) as unknown as Response;
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("https://auth.example.com/logout");
+  });
+});

--- a/app/utils/exportBoard.test.ts
+++ b/app/utils/exportBoard.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { exportToCSV, exportToMarkdown } from "./exportBoard";
+import type { Column } from "~/server/board.types";
+
+function makeColumn(title: string, notes: { text: string; likes: number }[]): Column {
+  return {
+    id: `col-${title}`,
+    title,
+    col_order: 0,
+    notes: notes.map((n, i) => ({
+      id: `note-${i}`,
+      column_id: `col-${title}`,
+      text: n.text,
+      likes: n.likes,
+      is_new: false,
+      created: "2026-01-01",
+      note_order: i,
+    })),
+  };
+}
+
+describe("exportToCSV", () => {
+  it("generates CSV with column headers and note data", () => {
+    const columns = [
+      makeColumn("Good", [{ text: "Fast deploys", likes: 3 }, { text: "Great teamwork", likes: 1 }]),
+      makeColumn("Bad", [{ text: "Slow reviews", likes: 2 }]),
+    ];
+
+    const csv = exportToCSV("Sprint 1", columns);
+    const lines = csv.split("\n");
+
+    expect(lines[0]).toBe("Good,Bad");
+    expect(lines[1]).toBe("Fast deploys (3),Slow reviews (2)");
+    expect(lines[2]).toBe("Great teamwork (1),");
+  });
+
+  it("pads shorter columns with empty cells", () => {
+    const columns = [
+      makeColumn("A", [{ text: "one", likes: 0 }, { text: "two", likes: 0 }, { text: "three", likes: 0 }]),
+      makeColumn("B", [{ text: "only", likes: 1 }]),
+      makeColumn("C", []),
+    ];
+
+    const csv = exportToCSV("Test", columns);
+    const lines = csv.split("\n");
+
+    expect(lines[0]).toBe("A,B,C");
+    expect(lines[1]).toBe("one (0),only (1),");
+    expect(lines[2]).toBe("two (0),,");
+    expect(lines[3]).toBe("three (0),,");
+  });
+
+  it("handles empty board with no columns", () => {
+    const csv = exportToCSV("Empty", []);
+    expect(csv).toBe("");
+  });
+
+  it("handles columns with no notes", () => {
+    const columns = [makeColumn("A", []), makeColumn("B", [])];
+    const csv = exportToCSV("Empty Notes", columns);
+    expect(csv).toBe("A,B");
+  });
+
+  it("escapes fields containing commas", () => {
+    const columns = [
+      makeColumn("Col", [{ text: "hello, world", likes: 0 }]),
+    ];
+
+    const csv = exportToCSV("Test", columns);
+    const lines = csv.split("\n");
+    expect(lines[1]).toBe('"hello, world (0)"');
+  });
+
+  it("escapes fields containing double quotes", () => {
+    const columns = [
+      makeColumn("Col", [{ text: 'said "wow"', likes: 1 }]),
+    ];
+
+    const csv = exportToCSV("Test", columns);
+    const lines = csv.split("\n");
+    expect(lines[1]).toBe('"said ""wow"" (1)"');
+  });
+
+  it("escapes fields containing newlines", () => {
+    const columns = [
+      makeColumn("Col", [{ text: "line1\nline2", likes: 0 }]),
+    ];
+
+    const csv = exportToCSV("Test", columns);
+    // The field should be quoted since it contains a newline
+    expect(csv).toContain('"line1\nline2 (0)"');
+  });
+});
+
+describe("exportToMarkdown", () => {
+  it("generates markdown with title, column headers, and bulleted notes", () => {
+    const columns = [
+      makeColumn("Good", [{ text: "Fast deploys", likes: 3 }, { text: "Great teamwork", likes: 1 }]),
+      makeColumn("Bad", [{ text: "Slow reviews", likes: 2 }]),
+    ];
+
+    const md = exportToMarkdown("Sprint 1", columns);
+    const lines = md.split("\n");
+
+    expect(lines[0]).toBe("# Sprint 1");
+    expect(lines[1]).toBe("");
+    expect(lines[2]).toBe("## Good");
+    expect(lines[3]).toBe("- Fast deploys (3)");
+    expect(lines[4]).toBe("- Great teamwork (1)");
+    expect(lines[5]).toBe("");
+    expect(lines[6]).toBe("## Bad");
+    expect(lines[7]).toBe("- Slow reviews (2)");
+  });
+
+  it("handles empty columns", () => {
+    const columns = [makeColumn("Empty", [])];
+
+    const md = exportToMarkdown("Test", columns);
+    expect(md).toContain("## Empty");
+    // No bullet items after the header
+    const lines = md.split("\n");
+    const headerIndex = lines.indexOf("## Empty");
+    expect(lines[headerIndex + 1]).toBe("");
+  });
+
+  it("handles empty board", () => {
+    const md = exportToMarkdown("Empty Board", []);
+    expect(md).toBe("# Empty Board\n");
+  });
+});

--- a/app/utils/exportBoard.ts
+++ b/app/utils/exportBoard.ts
@@ -1,0 +1,53 @@
+import type { Column } from "~/server/board.types";
+
+function escapeCSVField(field: string): string {
+  if (field.includes(",") || field.includes('"') || field.includes("\n")) {
+    return '"' + field.replace(/"/g, '""') + '"';
+  }
+  return field;
+}
+
+export function exportToCSV(_title: string, columns: Column[]): string {
+  if (columns.length === 0) return "";
+
+  const headers = columns.map((c) => c.title).join(",");
+  const maxNotes = Math.max(...columns.map((c) => c.notes.length));
+
+  if (maxNotes === 0) return headers;
+
+  const rows: string[] = [];
+  for (let i = 0; i < maxNotes; i++) {
+    const cells = columns.map((col) => {
+      const note = col.notes[i];
+      if (!note) return "";
+      return escapeCSVField(`${note.text} (${note.likes})`);
+    });
+    rows.push(cells.join(","));
+  }
+
+  return [headers, ...rows].join("\n");
+}
+
+export function exportToMarkdown(title: string, columns: Column[]): string {
+  const lines: string[] = [`# ${title}`, ""];
+
+  for (const col of columns) {
+    lines.push(`## ${col.title}`);
+    for (const note of col.notes) {
+      lines.push(`- ${note.text} (${note.likes})`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+export function downloadFile(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "tailwindcss": "^4.1.4",
         "typescript": "^5.8.3",
         "vite": "^6.3.3",
-        "vite-tsconfig-paths": "^5.1.4"
+        "vite-tsconfig-paths": "^5.1.4",
+        "vitest": "^4.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1510,6 +1511,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.13.tgz",
@@ -1787,6 +1795,24 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1891,6 +1917,133 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.0",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1925,6 +2078,16 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/babel-dead-code-elimination": {
       "version": "1.0.10",
@@ -2103,6 +2266,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -2448,6 +2621,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -2468,6 +2651,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -3102,9 +3295,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.19",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
-      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3306,6 +3499,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -4044,6 +4248,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4082,6 +4293,13 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -4090,6 +4308,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
@@ -4149,6 +4374,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4164,6 +4406,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -4432,6 +4684,119 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "react-router build",
     "dev": "react-router dev",
     "start": "react-router-serve ./build/server/index.js",
+    "test": "vitest run",
     "typecheck": "react-router typegen && tsc"
   },
   "dependencies": {
@@ -37,6 +38,7 @@
     "tailwindcss": "^4.1.4",
     "typescript": "^5.8.3",
     "vite": "^6.3.3",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^4.1.0"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: "node",
+  },
+});


### PR DESCRIPTION
- [#6]  Add an Export button to the board toolbar with a dropdown offer…ing CSV and Markdown download options. CSV exports column headers with notes as rows and like counts in parentheses. Markdown exports the board title as h1, column titles as h2, and notes as bulleted lists.
- Remove the broken /login route that called requireUser (which throws when no session exists) and let AccountHub link directly to /auth/login.
- Add vitest and tests for the auth login/callback/logout routes and the board export utilities.