### PR TITLE
Add board actions menu with duplicate and delete options

### DIFF
--- a/app/components/BoardActionsMenu.tsx
+++ b/app/components/BoardActionsMenu.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useRef, useState } from "react";
+import { useFetcher } from "react-router";
+import { EllipsisIcon, CopyIcon, TrashIcon } from "~/images/icons";
+
+interface BoardActionsMenuProps {
+  boardId: string;
+  boardTitle: string;
+  isOwner: boolean;
+}
+
+export function BoardActionsMenu({ boardId, boardTitle, isOwner }: BoardActionsMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const fetcher = useFetcher();
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (open && menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  // Close confirm dialog on outside click
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (confirmDelete && menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setConfirmDelete(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [confirmDelete]);
+
+  function handleDuplicate(e: React.MouseEvent) {
+    e.stopPropagation();
+    setOpen(false);
+    fetcher.submit(
+      { intent: "duplicate", boardId },
+      { method: "post" }
+    );
+  }
+
+  function handleDeleteClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    setOpen(false);
+    setConfirmDelete(true);
+  }
+
+  function handleConfirmDelete(e: React.MouseEvent) {
+    e.stopPropagation();
+    setConfirmDelete(false);
+    fetcher.submit(
+      { intent: "delete", boardId },
+      { method: "post" }
+    );
+  }
+
+  function handleCancelDelete(e: React.MouseEvent) {
+    e.stopPropagation();
+    setConfirmDelete(false);
+  }
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((o) => !o);
+          setConfirmDelete(false);
+        }}
+        className="p-1 rounded hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors cursor-pointer"
+      >
+        <EllipsisIcon size="md" />
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-1 w-52 rounded-md border bg-white dark:bg-gray-800 border-blue-500 shadow-lg z-50 overflow-hidden">
+          <button
+            type="button"
+            onClick={handleDuplicate}
+            className="flex items-center gap-3 w-full px-4 py-2.5 text-sm text-left hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+          >
+            <span className="text-gray-500 dark:text-gray-400"><CopyIcon size="sm" /></span>
+            Duplicate Board
+          </button>
+          {isOwner && (
+            <button
+              type="button"
+              onClick={handleDeleteClick}
+              className="flex items-center gap-3 w-full px-4 py-2.5 text-sm text-left text-red-600 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+            >
+              <span><TrashIcon size="sm" /></span>
+              Delete Board
+            </button>
+          )}
+        </div>
+      )}
+
+      {confirmDelete && (
+        <div className="absolute right-0 mt-1 w-72 rounded-md border bg-white dark:bg-gray-800 border-blue-500 shadow-lg z-50 overflow-hidden p-4 text-center">
+          <p className="text-sm font-medium mb-1">Delete "{boardTitle}"?</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+            This action cannot be undone.
+          </p>
+          <div className="flex justify-center gap-2">
+            <button
+              type="button"
+              onClick={handleConfirmDelete}
+              className="px-3 py-1.5 text-sm rounded bg-red-500 text-white hover:bg-red-600 transition-colors cursor-pointer"
+            >
+              Delete
+            </button>
+            <button
+              type="button"
+              onClick={handleCancelDelete}
+              className="px-3 py-1.5 text-sm rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/images/icons.tsx
+++ b/app/images/icons.tsx
@@ -558,6 +558,44 @@ export function DownloadIcon({ size = 'md', className = '' }: IconProps) {
   );
 }
 
+export function EllipsisIcon({ size = 'md', className = '' }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={`${sizeMap[size]} ${className}`}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M6.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM12.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM18.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"
+      />
+    </svg>
+  );
+}
+
+export function CopyIcon({ size = 'md', className = '' }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={`${sizeMap[size]} ${className}`}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75"
+      />
+    </svg>
+  );
+}
+
 export function CloseIcon({ size = 'md', className = '' }: IconProps) {
   return (
     <svg

--- a/app/routes/app/dashboard.tsx
+++ b/app/routes/app/dashboard.tsx
@@ -2,13 +2,14 @@ import { useState } from "react";
 import { Form, useLoaderData, useSearchParams, redirect, type ActionFunctionArgs, useNavigate } from "react-router";
 import { requireUser } from "~/hooks/useAuth";
 import { pool } from "~/server/db_config";
-import { createBoard } from "~/server/board_model";
+import { createBoard, duplicateBoardServer, deleteBoardServer } from "~/server/board_model";
 import { PlusIcon, CheckIcon } from "~/images/icons";
 import Button from "~/components/Button";
 import { WelcomeBanner } from "~/components/WelcomeBanner";
 import pkg from "~/../package.json";
 import { NewButton } from "~/components/NewButton";
 import { ClaimModal } from "~/components/ClaimModal";
+import { BoardActionsMenu } from "~/components/BoardActionsMenu";
 
 export async function loader({ request }: { request: Request }) {
   const user = await requireUser(request);
@@ -42,14 +43,26 @@ export async function loader({ request }: { request: Request }) {
 
 export async function action({ request }: ActionFunctionArgs) {
   const user = await requireUser(request);
-
   const formData = await request.formData();
+  const intent = formData.get("intent")?.toString();
+
+  if (intent === "duplicate") {
+    const boardId = formData.get("boardId")?.toString();
+    if (!boardId) throw new Response("Missing boardId", { status: 400 });
+    const newBoardId = await duplicateBoardServer(boardId, user.id);
+    return redirect(`/app/board/${newBoardId}`);
+  }
+
+  if (intent === "delete") {
+    const boardId = formData.get("boardId")?.toString();
+    if (!boardId) throw new Response("Missing boardId", { status: 400 });
+    await deleteBoardServer(boardId, user.id);
+    return redirect("/app/dashboard");
+  }
+
+  // Default: create board
   const title = formData.get("title")?.toString().trim() || "Untitled";
-
-  // create the board in the database
   const board_id = await createBoard(title, user.id);
-
-  // redirect to the new board
   return redirect(`/app/board/${board_id}`);
 }
 
@@ -131,6 +144,7 @@ export default function AppDashboard() {
                       {field}
                     </th>
                   ))}
+                  <th className="border-b-2 px-4 py-2" />
                 </tr>
               </thead>
               <tbody>
@@ -153,6 +167,13 @@ export default function AppDashboard() {
                     </td>
                     <td className="border-b dark:border-gray-600 px-4 py-4">
                       {new Date(board.created_at).toLocaleDateString()}
+                    </td>
+                    <td className="border-b dark:border-gray-600 px-4 py-2 text-right">
+                      <BoardActionsMenu
+                        boardId={board.id}
+                        boardTitle={board.title}
+                        isOwner={board.role === "owner"}
+                      />
                     </td>
                   </tr>
                 ))}

--- a/app/server/board_model.test.ts
+++ b/app/server/board_model.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockQuery = vi.fn();
+const mockRelease = vi.fn();
+vi.mock("~/server/db_config", () => ({
+  pool: {
+    connect: vi.fn(async () => ({
+      query: mockQuery,
+      release: mockRelease,
+    })),
+  },
+}));
+
+vi.mock("~/server/db_init", () => ({}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("duplicateBoardServer", () => {
+  it("creates a new board with '(copy)' suffix and copies columns", async () => {
+    const { duplicateBoardServer } = await import("./board_model");
+
+    // BEGIN
+    mockQuery.mockResolvedValueOnce({});
+    // SELECT title
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ title: "Sprint 1" }] });
+    // INSERT board
+    mockQuery.mockResolvedValueOnce({});
+    // INSERT board_member
+    mockQuery.mockResolvedValueOnce({});
+    // SELECT columns
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { title: "Good", col_order: 0 },
+        { title: "Bad", col_order: 1 },
+        { title: "Actions", col_order: 2 },
+      ],
+    });
+    // 3x INSERT column
+    mockQuery.mockResolvedValueOnce({});
+    mockQuery.mockResolvedValueOnce({});
+    mockQuery.mockResolvedValueOnce({});
+    // COMMIT
+    mockQuery.mockResolvedValueOnce({});
+
+    const newId = await duplicateBoardServer("board-1", "user-1");
+
+    expect(typeof newId).toBe("string");
+    expect(newId).toHaveLength(36); // UUID format
+
+    // Verify board title includes "(copy)"
+    const insertBoardCall = mockQuery.mock.calls[2];
+    expect(insertBoardCall[0]).toContain("INSERT INTO boards");
+    expect(insertBoardCall[1][1]).toBe("Sprint 1 (copy)");
+
+    // Verify owner membership
+    const insertMemberCall = mockQuery.mock.calls[3];
+    expect(insertMemberCall[0]).toContain("INSERT INTO board_members");
+    expect(insertMemberCall[0]).toContain("owner");
+    expect(insertMemberCall[1][1]).toBe("user-1");
+
+    // Verify 3 columns were copied
+    const colInserts = mockQuery.mock.calls.slice(5, 8);
+    expect(colInserts[0][1][2]).toBe("Good");
+    expect(colInserts[1][1][2]).toBe("Bad");
+    expect(colInserts[2][1][2]).toBe("Actions");
+
+    // Verify transaction committed
+    expect(mockQuery.mock.calls[8][0]).toBe("COMMIT");
+
+    // Verify client was released
+    expect(mockRelease).toHaveBeenCalled();
+  });
+
+  it("throws and rolls back when board is not found", async () => {
+    const { duplicateBoardServer } = await import("./board_model");
+
+    mockQuery.mockResolvedValueOnce({}); // BEGIN
+    mockQuery.mockResolvedValueOnce({ rowCount: 0, rows: [] }); // SELECT title - not found
+    mockQuery.mockResolvedValueOnce({}); // ROLLBACK
+
+    await expect(duplicateBoardServer("bad-id", "user-1")).rejects.toThrow("Board not found");
+    expect(mockRelease).toHaveBeenCalled();
+  });
+});
+
+describe("deleteBoardServer", () => {
+  it("deletes board and all related data when user is owner", async () => {
+    const { deleteBoardServer } = await import("./board_model");
+
+    mockQuery.mockResolvedValueOnce({}); // BEGIN
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ role: "owner" }] }); // SELECT role
+    mockQuery.mockResolvedValueOnce({}); // DELETE notes
+    mockQuery.mockResolvedValueOnce({}); // DELETE columns
+    mockQuery.mockResolvedValueOnce({}); // DELETE board_members
+    mockQuery.mockResolvedValueOnce({}); // DELETE board
+    mockQuery.mockResolvedValueOnce({}); // COMMIT
+
+    await deleteBoardServer("board-1", "user-1");
+
+    // Verify ownership check
+    const roleCheck = mockQuery.mock.calls[1];
+    expect(roleCheck[0]).toContain("board_members");
+    expect(roleCheck[1]).toEqual(["board-1", "user-1"]);
+
+    // Verify deletions happened in order
+    expect(mockQuery.mock.calls[2][0]).toContain("DELETE FROM notes");
+    expect(mockQuery.mock.calls[3][0]).toContain("DELETE FROM columns");
+    expect(mockQuery.mock.calls[4][0]).toContain("DELETE FROM board_members");
+    expect(mockQuery.mock.calls[5][0]).toContain("DELETE FROM boards");
+    expect(mockQuery.mock.calls[6][0]).toBe("COMMIT");
+
+    expect(mockRelease).toHaveBeenCalled();
+  });
+
+  it("throws and rolls back when user is not the owner", async () => {
+    const { deleteBoardServer } = await import("./board_model");
+
+    mockQuery.mockResolvedValueOnce({}); // BEGIN
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ role: "member" }] }); // not owner
+    mockQuery.mockResolvedValueOnce({}); // ROLLBACK
+
+    await expect(deleteBoardServer("board-1", "user-2")).rejects.toThrow(
+      "Only the board owner can delete a board"
+    );
+    expect(mockRelease).toHaveBeenCalled();
+  });
+
+  it("throws and rolls back when user is not a member at all", async () => {
+    const { deleteBoardServer } = await import("./board_model");
+
+    mockQuery.mockResolvedValueOnce({}); // BEGIN
+    mockQuery.mockResolvedValueOnce({ rowCount: 0, rows: [] }); // no membership
+    mockQuery.mockResolvedValueOnce({}); // ROLLBACK
+
+    await expect(deleteBoardServer("board-1", "stranger")).rejects.toThrow(
+      "Only the board owner can delete a board"
+    );
+    expect(mockRelease).toHaveBeenCalled();
+  });
+});

--- a/app/server/board_model.ts
+++ b/app/server/board_model.ts
@@ -248,6 +248,100 @@ export async function stopTimerServer(boardId: string): Promise<void> {
   );
 }
 
+export async function duplicateBoardServer(
+  boardId: string,
+  userId: string
+): Promise<string> {
+  const client = await pool.connect();
+  const newId = crypto.randomUUID();
+
+  try {
+    await client.query("BEGIN");
+
+    // Get the original board title
+    const boardRes = await client.query(
+      `SELECT title FROM boards WHERE id = $1`,
+      [boardId]
+    );
+    if (boardRes.rowCount === 0) throw new Error("Board not found");
+    const newTitle = `${boardRes.rows[0].title} (copy)`;
+
+    // Create the new board
+    await client.query(
+      `INSERT INTO boards (id, title, created_by) VALUES ($1, $2, $3)`,
+      [newId, newTitle, userId]
+    );
+
+    // Add the user as owner
+    await client.query(
+      `INSERT INTO board_members (board_id, user_id, role) VALUES ($1, $2, 'owner')`,
+      [newId, userId]
+    );
+
+    // Copy columns (without notes)
+    const cols = await client.query(
+      `SELECT title, col_order FROM columns WHERE board_id = $1 ORDER BY col_order`,
+      [boardId]
+    );
+    for (const col of cols.rows) {
+      await client.query(
+        `INSERT INTO columns (id, board_id, title, col_order) VALUES ($1, $2, $3, $4)`,
+        [crypto.randomUUID(), newId, col.title, col.col_order]
+      );
+    }
+
+    await client.query("COMMIT");
+    return newId;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+export async function deleteBoardServer(
+  boardId: string,
+  userId: string
+): Promise<void> {
+  const client = await pool.connect();
+
+  try {
+    await client.query("BEGIN");
+
+    // Verify the user is the owner
+    const memberRes = await client.query(
+      `SELECT role FROM board_members WHERE board_id = $1 AND user_id = $2`,
+      [boardId, userId]
+    );
+    if (memberRes.rowCount === 0 || memberRes.rows[0].role !== "owner") {
+      throw new Error("Only the board owner can delete a board");
+    }
+
+    // Delete notes for all columns in this board
+    await client.query(
+      `DELETE FROM notes WHERE column_id IN (SELECT id FROM columns WHERE board_id = $1)`,
+      [boardId]
+    );
+
+    // Delete columns
+    await client.query(`DELETE FROM columns WHERE board_id = $1`, [boardId]);
+
+    // Delete board members
+    await client.query(`DELETE FROM board_members WHERE board_id = $1`, [boardId]);
+
+    // Delete the board
+    await client.query(`DELETE FROM boards WHERE id = $1`, [boardId]);
+
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
 export async function updateBoardTitleServer(boardId: string, newTitle: string) {
   await pool.query(`UPDATE boards SET title = $1 WHERE id = $2`, [newTitle, boardId]);
   return getBoardServer(boardId);


### PR DESCRIPTION
Adds a "..." dropdown menu to each board row on the dashboard with options to duplicate a board (copies columns only) or delete it (owner-only, with confirmation dialog). Includes backend functions and unit tests.

Closes #18 