### PR TITLE
Add voting system and dashboard/UI polish (#16)

### DIFF
--- a/app/components/AccountHub.tsx
+++ b/app/components/AccountHub.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import { MoonIcon, SunIcon, UserIcon, ComputerIcon } from '~/images/icons';
 import { useTheme } from '~/hooks/useTheme';
 import Button from './Button';
+import { siteConfig } from '~/config/siteConfig';
 
 interface AccountHubProps {
   user?: {
@@ -116,15 +117,19 @@ export default function AccountHub({ user, closeMenu }: AccountHubProps) {
           </div>
 
           {/* Log Out */}
-          <div className="border-t border-gray-200 dark:border-gray-700" />
-          <Button
-            as="a"
-            href="/auth/logout"
-            variant="text"
-            color="danger"
-            text="Logout"
-            className="w-full justify-start"
-          />
+          {!siteConfig.dashboardHome &&
+            <>
+              <div className="border-t border-gray-200 dark:border-gray-700" />
+              <Button
+                as="a"
+                href="/auth/logout"
+                variant="text"
+                color="danger"
+                text="Logout"
+                className="w-full justify-start"
+              />
+            </>
+          }
         </div>
       </div>
     </div>

--- a/app/components/BoardSettingsModal.tsx
+++ b/app/components/BoardSettingsModal.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useRef, useState } from "react";
+import { useFetcher } from "react-router";
+import { useBoard } from "~/context/BoardContext";
+import { CloseIcon } from "~/images/icons";
+import type { BoardDTO } from "~/server/board.types";
+
+interface BoardSettingsModalProps {
+  onClose: () => void;
+}
+
+export function BoardSettingsModal({ onClose }: BoardSettingsModalProps) {
+  const { id: boardId, votingEnabled, votingAllowed, updateBoardSettings } = useBoard();
+  const clearFetcher = useFetcher();
+
+  const [localEnabled, setLocalEnabled] = useState(votingEnabled);
+  const [localAllowed, setLocalAllowed] = useState(votingAllowed);
+  const [showClearWarning, setShowClearWarning] = useState(false);
+
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [onClose]);
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  // When the clear fetcher completes, save the new settings
+  useEffect(() => {
+    if (clearFetcher.data) {
+      updateBoardSettings(true, localAllowed);
+      onClose();
+    }
+  }, [clearFetcher.data]);
+
+  function handleToggleVoting(enabled: boolean) {
+    setLocalEnabled(enabled);
+    if (enabled && !votingEnabled) {
+      // Turning on — show warning about clearing likes
+      setShowClearWarning(true);
+    } else if (!enabled) {
+      setShowClearWarning(false);
+    }
+  }
+
+  function handleSave() {
+    if (showClearWarning) {
+      // User clicked save while warning is shown — they already saw it; confirm
+      handleConfirmClear();
+    } else {
+      updateBoardSettings(localEnabled, localAllowed);
+      onClose();
+    }
+  }
+
+  function handleConfirmClear() {
+    // Clear all likes/votes on the server, then save settings
+    clearFetcher.submit(
+      {},
+      { method: "POST", action: `/app/board/${boardId}/settings` }
+    );
+  }
+
+  function handleCancelClear() {
+    setLocalEnabled(false);
+    setShowClearWarning(false);
+  }
+
+  const isSaving = clearFetcher.state !== "idle";
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div
+        ref={modalRef}
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-md mx-4 p-6"
+      >
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-lg font-semibold">Board Settings</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+          >
+            <CloseIcon size="md" />
+          </button>
+        </div>
+
+        <div className="space-y-6">
+          {/* Voting toggle */}
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="font-medium text-sm">Voting System</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                Replace likes with a limited vote counter
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={localEnabled}
+              onClick={() => handleToggleVoting(!localEnabled)}
+              className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none
+                ${localEnabled ? "bg-blue-600" : "bg-gray-300 dark:bg-gray-600"}`}
+            >
+              <span
+                className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow ring-0 transition-transform
+                  ${localEnabled ? "translate-x-5" : "translate-x-0"}`}
+              />
+            </button>
+          </div>
+
+          {/* Votes allowed */}
+          {localEnabled && (
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-medium text-sm">Votes per person</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                  How many votes each participant can cast
+                </p>
+              </div>
+              <input
+                type="number"
+                min={1}
+                max={99}
+                value={localAllowed}
+                onChange={(e) => setLocalAllowed(Math.max(1, Number(e.target.value)))}
+                className="w-16 text-center border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700"
+              />
+            </div>
+          )}
+
+          {/* Clear warning */}
+          {showClearWarning && (
+            <div className="rounded-md bg-amber-50 dark:bg-amber-900/30 border border-amber-300 dark:border-amber-600 p-3 text-sm text-amber-800 dark:text-amber-200">
+              <p className="font-medium mb-1">Enabling voting will clear all existing likes.</p>
+              <p>This cannot be undone. Do you want to continue?</p>
+              <div className="flex gap-2 mt-3">
+                <button
+                  type="button"
+                  onClick={handleConfirmClear}
+                  disabled={isSaving}
+                  className="px-3 py-1.5 rounded bg-amber-600 text-white text-sm hover:bg-amber-700 transition-colors disabled:opacity-50 cursor-pointer"
+                >
+                  {isSaving ? "Clearing…" : "Yes, clear likes"}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleCancelClear}
+                  className="px-3 py-1.5 rounded border border-gray-300 dark:border-gray-600 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+                >
+                  Abort
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        {!showClearWarning && (
+          <div className="flex justify-end gap-2 mt-8">
+            <button
+              type="button"
+              onClick={handleSave}
+              className="px-4 py-2 text-sm rounded bg-blue-600 text-white hover:bg-blue-700 transition-colors cursor-pointer"
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+            >
+              Abort
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/BoardToolbar.tsx
+++ b/app/components/BoardToolbar.tsx
@@ -3,13 +3,15 @@ import TimerButton from "./TimerButton";
 import ExportButton from "./ExportButton";
 import Button from "./Button";
 import { useBoard } from "~/context/BoardContext";
-import { EditIcon, PlusIcon } from "~/images/icons";
+import { EditIcon, PlusIcon, SettingsIcon } from "~/images/icons";
 import TimerDisplay from "./TimerDisplay";
+import { BoardSettingsModal } from "./BoardSettingsModal";
 
 export default function BoardToolbar({ title }: { title: string }) {
-  const { addColumn, updateTitle } = useBoard();
+  const { addColumn, updateTitle, isOwner, votingEnabled, votingAllowed, columns } = useBoard();
   const [editing, setEditing] = useState(false);
   const [localTitle, setLocalTitle] = useState(title);
+  const [showSettings, setShowSettings] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Keep local state in sync if server pushes a new title (multi-user)
@@ -39,36 +41,60 @@ export default function BoardToolbar({ title }: { title: string }) {
     }
   };
 
+  // Compute how many votes the current user has cast (user_voted notes count)
+  const votesUsed = votingEnabled
+    ? columns.flatMap((c) => c.notes).filter((n) => n.user_voted).length
+    : 0;
+  const votesRemaining = votingAllowed - votesUsed;
+
   return (
-    <div className="flex justify-between items-center py-4 gap-4">
-      {editing ? (
-        <input
-          ref={inputRef}
-          value={localTitle}
-          onChange={(e) => setLocalTitle(e.target.value)}
-          onBlur={save}
-          onKeyDown={handleKeyDown}
-          className="text-4xl font-bold border rounded w-full p-2 my-4"
+    <>
+      <div className="flex justify-between items-center py-4 gap-4">
+        {editing ? (
+          <input
+            ref={inputRef}
+            value={localTitle}
+            onChange={(e) => setLocalTitle(e.target.value)}
+            onBlur={save}
+            onKeyDown={handleKeyDown}
+            className="text-4xl font-bold border rounded w-full p-2 my-4"
+          />
+        ) : (
+          <h1
+            onClick={() => setEditing(true)}
+            className={"inline-flex gap-2 items-baseline cursor-text hover:bg-slate-200 dark:hover:bg-slate-950 p-2 my-4 border border-transparent rounded-md"}
+            title="Click to edit title"
+          >
+            {localTitle}
+          </h1>
+        )}
+        <div className="flex-grow text-center">
+          <TimerDisplay />
+        </div>
+        {votingEnabled && (
+          <div className="text-sm font-medium text-gray-600 dark:text-gray-300 whitespace-nowrap">
+            {votesRemaining} vote{votesRemaining !== 1 ? "s" : ""} remaining
+          </div>
+        )}
+        <TimerButton />
+        <ExportButton />
+        <Button
+          icon={<PlusIcon />}
+          text="Column"
+          onClick={() => addColumn()}
         />
-      ) : (
-        <h1
-          onClick={() => setEditing(true)}
-          className={"inline-flex gap-2 items-baseline cursor-text hover:bg-slate-200 dark:hover:bg-slate-950 p-2 my-4 border border-transparent rounded-md"}
-          title="Click to edit title"
-        >
-          {localTitle}
-        </h1>
-      )}
-      <div className="flex-grow text-center">
-        <TimerDisplay />
+        {isOwner && (
+          <Button
+            icon={<SettingsIcon />}
+            onClick={() => setShowSettings(true)}
+            variant="text"
+            title="Board settings"
+          />
+        )}
       </div>
-      <TimerButton />
-      <ExportButton />
-      <Button
-        icon={<PlusIcon />}
-        text="Column"
-        onClick={() => addColumn()}
-      />
-    </div>
+      {showSettings && (
+        <BoardSettingsModal onClose={() => setShowSettings(false)} />
+      )}
+    </>
   );
 }

--- a/app/components/Note.tsx
+++ b/app/components/Note.tsx
@@ -3,8 +3,9 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import debounce from "lodash.debounce";
 import { useBoard } from "../context/BoardContext";
+import { useOptionalUser } from "~/context/userContext";
 import type { Note } from "~/server/board.types";
-import { EditIcon, ThumbsUpIcon, TrashIcon } from "~/images/icons";
+import { EditIcon, ThumbsUpIcon, ThumbsUpFilledIcon, TrashIcon } from "~/images/icons";
 import Button from "./Button";
 
 export default function Note({
@@ -16,7 +17,8 @@ export default function Note({
   columnId: string,
   noteColor: string
 }) {
-  const { updateNote, deleteNote, likeNote } = useBoard();
+  const { updateNote, deleteNote, likeNote, voteNote, votingEnabled, votingAllowed, columns } = useBoard();
+  const user = useOptionalUser();
   const [isEditing, setIsEditing] = useState(note.is_new);
   const [text, setText] = useState(note.text);
   const [likes, setLikes] = useState(note.likes);
@@ -64,6 +66,19 @@ export default function Note({
     pendingLikes.current += 1;
     setLikes(prev => prev + 1);
     flushLikes();
+  };
+
+  // Count votes the user has already cast across the board
+  const votesUsed = columns.flatMap((c) => c.notes).filter((n) => n.user_voted).length;
+  const votesRemaining = votingAllowed - votesUsed;
+  const userVoted = note.user_voted ?? false;
+
+  // Vote is allowed if: user is logged in, they haven't maxed out votes, OR they're un-voting
+  const canVote = !!user && (userVoted || votesRemaining > 0);
+
+  const handleVote = () => {
+    if (!canVote) return;
+    voteNote(note.id);
   };
 
   // save note (on blur or enter)
@@ -130,15 +145,39 @@ export default function Note({
             </div>
           ) : (
             <div className='flex justify-start items-center'>
-              <Button
-                text={likes.toString()}
-                icon={<ThumbsUpIcon size="sm" />}
-                onClick={handleLike}
-                onDoubleClick={(e: Event) => e.stopPropagation()}
-                variant="text"
-                size='sm'
-                className="dark:hover:bg-[rgba(0,0,0,0.1)]"
-              />
+              {votingEnabled ? (
+                <Button
+                  text={(note.votes ?? 0).toString()}
+                  icon={userVoted
+                    ? <ThumbsUpFilledIcon size="sm" className="text-blue-600" />
+                    : <ThumbsUpIcon size="sm" />
+                  }
+                  onClick={handleVote}
+                  onDoubleClick={(e: Event) => e.stopPropagation()}
+                  variant="text"
+                  size='sm'
+                  className={`dark:hover:bg-[rgba(0,0,0,0.1)] ${!canVote ? "opacity-40 cursor-not-allowed" : ""}`}
+                  title={
+                    !user
+                      ? "Log in to vote"
+                      : !canVote
+                      ? "No votes remaining"
+                      : userVoted
+                      ? "Remove vote"
+                      : "Cast vote"
+                  }
+                />
+              ) : (
+                <Button
+                  text={likes.toString()}
+                  icon={<ThumbsUpIcon size="sm" />}
+                  onClick={handleLike}
+                  onDoubleClick={(e: Event) => e.stopPropagation()}
+                  variant="text"
+                  size='sm'
+                  className="dark:hover:bg-[rgba(0,0,0,0.1)]"
+                />
+              )}
               <div className='grow' />
               <Button
                 icon={<EditIcon size="sm" />}

--- a/app/components/WelcomeBanner.tsx
+++ b/app/components/WelcomeBanner.tsx
@@ -6,7 +6,7 @@ export interface WelcomeMessage {
   id: string;
   title: string;
   message: string;
-  link: string;
+  link?: string;
 }
 
 const STORAGE_KEY = (id: string) => `welcome_dismissed:${id}`;
@@ -40,13 +40,15 @@ export function WelcomeBanner({ id, title, message, link }: WelcomeMessage) {
         <p>{message}</p>
       </div>
       <div className="flex justify-end items-center gap-2 w-full">
-        <Button
-          variant="solid"
-          color="primary"
-          onClick={() => window.open(link, "_blank")}
-          aria-label="release notes"
-          text="v1.2.1 Release Notes"
-        />
+        {link &&
+          <Button
+            variant="solid"
+            color="primary"
+            onClick={() => window.open(link, "_blank")}
+            aria-label="release notes"
+            text="Release Notes"
+          />
+        }
         <Button
           variant="solid"
           color="muted"

--- a/app/config/siteConfig.ts
+++ b/app/config/siteConfig.ts
@@ -3,6 +3,7 @@
 
 export type SiteConfig = {
   dashboardHome: boolean;
+  usernameField: string;
   logoLight?: string;
   logoDark?: string;
   logoAlt?: string;
@@ -11,8 +12,11 @@ export type SiteConfig = {
 export const siteConfig: SiteConfig = {
   // This will make / redirect to the /app/dashboard instead of the default landing page.
   // Essntially making the dashboard the home page.  Good for when SSO will automatically
-  // log users in.
+  // log users in. This will disable the logout feature.
   dashboardHome: false,
+
+  // If you are using SSO, set the username field to whatever field in the OIDC token you want to use as the username.
+  usernameField: "preferred_username",
 
   // if you are going to provide logos, you must provide both light and dark 
   // versions for proper theming support. Import them at the top of this file 

--- a/app/context/BoardContext.tsx
+++ b/app/context/BoardContext.tsx
@@ -89,12 +89,16 @@ export function BoardProvider({ children }: { children: React.ReactNode }) {
   const columnFetcher = useFetcher();
   const noteFetcher = useFetcher();
   const timerFetcher = useFetcher();
+  const settingsFetcher = useFetcher();
 
   const [columns, setColumns] = useState<Column[]>(loaderData.columns);
   const [timerRunning, setTimerRunning] = useState(loaderData.timerRunning);
   const [timerEndsAt, setTimerEndsAt] = useState<string | null>(loaderData.timerEndsAt);
   const [timeLeft, setTimeLeft] = useState<number | null>(null);
   const [offline, setOffline] = useState(false);
+  const [votingEnabled, setVotingEnabled] = useState(loaderData.votingEnabled ?? false);
+  const [votingAllowed, setVotingAllowed] = useState(loaderData.votingAllowed ?? 5);
+  const isOwner = loaderData.isOwner ?? false;
 
   // ---------------------------------------------------------------------------
   // Sync server → local when loader revalidates
@@ -107,6 +111,11 @@ export function BoardProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     setTitle(loaderData.title);
   }, [loaderData.title]);
+
+  useEffect(() => {
+    setVotingEnabled(loaderData.votingEnabled ?? false);
+    setVotingAllowed(loaderData.votingAllowed ?? 5);
+  }, [loaderData.votingEnabled, loaderData.votingAllowed]);
 
   // Sync timer from server (other users may have started/stopped it).
   // timerEndsAt is always a UTC ISO string (forced by the SQL query), so
@@ -126,6 +135,15 @@ export function BoardProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (noteFetcher.data) setColumns((noteFetcher.data as BoardDTO).columns as Column[]);
   }, [noteFetcher.data]);
+
+  useEffect(() => {
+    if (settingsFetcher.data) {
+      const data = settingsFetcher.data as BoardDTO;
+      setColumns(data.columns as Column[]);
+      setVotingEnabled(data.votingEnabled ?? false);
+      setVotingAllowed(data.votingAllowed ?? 5);
+    }
+  }, [settingsFetcher.data]);
 
   // ---------------------------------------------------------------------------
   // Polling for multi-user sync — plain fetch() bypasses RR7's turbostream
@@ -152,6 +170,8 @@ export function BoardProvider({ children }: { children: React.ReactNode }) {
         setOffline(false);
         setColumns((prev) => mergeColumns(data.columns as Column[], prev));
         setTitle(data.title);
+        setVotingEnabled(data.votingEnabled ?? false);
+        setVotingAllowed(data.votingAllowed ?? 5);
 
         syncTimerState(data, timerRunning, timerEndsAt, setTimerRunning, setTimerEndsAt);
       } catch (err) {
@@ -421,6 +441,24 @@ export function BoardProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
+  const voteNote = (noteId: string) => {
+    if (isReadOnly) return;
+    noteFetcher.submit(
+      { intent: "vote", noteId },
+      { method: "PATCH", action: `/app/board/${boardId}/notes` }
+    );
+  };
+
+  const updateBoardSettings = (newVotingEnabled: boolean, newVotingAllowed: number) => {
+    if (isReadOnly) return;
+    setVotingEnabled(newVotingEnabled);
+    setVotingAllowed(newVotingAllowed);
+    settingsFetcher.submit(
+      { votingEnabled: String(newVotingEnabled), votingAllowed: newVotingAllowed },
+      { method: "PATCH", action: `/app/board/${boardId}/settings` }
+    );
+  };
+
   // ---------------------------------------------------------------------------
   // Timer actions
   // ---------------------------------------------------------------------------
@@ -459,12 +497,15 @@ export function BoardProvider({ children }: { children: React.ReactNode }) {
     title,
     updateTitle,
     readonly: isReadOnly,
+    isOwner,
     columns,
     nextColOrder: deriveNextColOrder(columns),
     offline,
     timerRunning,
     timerEndsAt,
     timeLeft,
+    votingEnabled,
+    votingAllowed,
     addColumn,
     updateColumnTitle,
     updateColumnPrompt,
@@ -472,6 +513,8 @@ export function BoardProvider({ children }: { children: React.ReactNode }) {
     addNote,
     updateNote,
     likeNote,
+    voteNote,
+    updateBoardSettings,
     deleteNote,
     moveNote,
     reorderNote,

--- a/app/hooks/useAuth.ts
+++ b/app/hooks/useAuth.ts
@@ -1,6 +1,7 @@
 import { redirect } from "react-router";
 import { getSession } from "~/session.server";
 import { pool } from "~/server/db_config";
+import { siteConfig } from "~/config/siteConfig";
 
 export async function getOptionalUser(request: Request) {
   const session = await getSession(request.headers.get("Cookie"));
@@ -17,7 +18,9 @@ export async function getOptionalUser(request: Request) {
     return null;
   }
 
-  const { id, preferred_username: username } = user;
+  const id = user.id;
+  const username = user[siteConfig.usernameField];
+
   return { id, username };
 }
 

--- a/app/images/icons.tsx
+++ b/app/images/icons.tsx
@@ -596,6 +596,39 @@ export function CopyIcon({ size = 'md', className = '' }: IconProps) {
   );
 }
 
+// Filled thumbs up — shown when the current user has voted on a note
+export function ThumbsUpFilledIcon({ size = 'md', className = '' }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={`${sizeMap[size]} ${className}`}
+    >
+      <path d="M7 22H4a1 1 0 0 1-1-1V10a1 1 0 0 1 1-1h3v13z" />
+      <path d="M20.6 11.3l-1.2 7.2A1.5 1.5 0 0 1 18 20H9V9.5l3-7c.8 0 1.5.3 2 .9.4.5.6 1.1.5 1.7L14 8h4.6a1.5 1.5 0 0 1 1.5 1.5c0 .3-.1.6-.2.9l-.3.9z" />
+    </svg>
+  );
+}
+
+export function SettingsIcon({ size = 'md', className = '' }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`${sizeMap[size]} ${className}`}
+    >
+      <path d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
+      <path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+    </svg>
+  );
+}
+
 export function CloseIcon({ size = 'md', className = '' }: IconProps) {
   return (
     <svg

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -29,6 +29,7 @@ export default [
     route("notes", "routes/app/board.notes.ts"),
     route("timer", "routes/app/board.timer.ts"),
     route("poll", "routes/app/board.poll.ts"),
+    route("settings", "routes/app/board.settings.ts"),
   ]),
 
   /* Api Routes */

--- a/app/routes/app/board.notes.ts
+++ b/app/routes/app/board.notes.ts
@@ -4,9 +4,11 @@
 // DELETE → delete note
 
 import { type ActionFunctionArgs } from "react-router";
+import { getOptionalUser } from "~/hooks/useAuth";
 import {
   upsertNoteServer,
   likeNoteServer,
+  voteNoteServer,
   deleteNoteServer,
   moveNoteServer,
   reorderNotesServer,
@@ -49,6 +51,14 @@ export async function action({ request, params }: ActionFunctionArgs) {
           throw new Response("Missing like fields", { status: 422 });
         }
         return likeNoteServer(boardId, noteId, delta);
+      }
+
+      if (intent === "vote") {
+        const noteId = data.get("noteId") as string;
+        if (!noteId) throw new Response("Missing noteId", { status: 422 });
+        const user = await getOptionalUser(request);
+        if (!user) throw new Response("Unauthorized", { status: 401 });
+        return voteNoteServer(boardId, noteId, user.id);
       }
 
       // default PATCH: update note content

--- a/app/routes/app/board.poll.ts
+++ b/app/routes/app/board.poll.ts
@@ -1,12 +1,14 @@
 // routes/app/board.poll.ts
 import { type LoaderFunctionArgs } from "react-router";
 import { getBoardServer, stopTimerServer } from "~/server/board_model";
+import { getOptionalUser } from "~/hooks/useAuth";
 
-export async function loader({ params }: LoaderFunctionArgs) {
+export async function loader({ request, params }: LoaderFunctionArgs) {
   const { id: boardId } = params;
   if (!boardId) throw new Response("Missing ID", { status: 400 });
 
-  const board = await getBoardServer(boardId);
+  const user = await getOptionalUser(request);
+  const board = await getBoardServer(boardId, user?.id);
   if (!board) throw new Response("Not Found", { status: 404 });
 
   if (board.timerRunning && board.timerEndsAt) {

--- a/app/routes/app/board.settings.ts
+++ b/app/routes/app/board.settings.ts
@@ -1,0 +1,56 @@
+// routes/app/board.settings.ts
+// Resource route — no UI. Handles board settings mutations.
+// PATCH → update voting_enabled and voting_allowed
+// POST  → clear all votes and likes (called before enabling voting)
+
+import { type ActionFunctionArgs } from "react-router";
+import { getOptionalUser } from "~/hooks/useAuth";
+import {
+  updateBoardSettingsServer,
+  clearBoardVotesServer,
+  getBoardServer,
+} from "~/server/board_model";
+import { pool } from "~/server/db_config";
+
+async function requireOwner(request: Request, boardId: string) {
+  const user = await getOptionalUser(request);
+  if (!user) throw new Response("Unauthorized", { status: 401 });
+
+  const res = await pool.query(
+    `SELECT role FROM board_members WHERE board_id = $1 AND user_id = $2`,
+    [boardId, user.id]
+  );
+  if (res.rowCount === 0 || res.rows[0].role !== "owner") {
+    throw new Response("Forbidden", { status: 403 });
+  }
+  return user;
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  const { id: boardId } = params;
+  if (!boardId) throw new Response("Board ID Missing", { status: 400 });
+
+  const data = await request.formData();
+
+  switch (request.method.toUpperCase()) {
+    case "PATCH": {
+      const user = await requireOwner(request, boardId);
+      const votingEnabled = data.get("votingEnabled") === "true";
+      const votingAllowed = Number(data.get("votingAllowed"));
+      if (isNaN(votingAllowed) || votingAllowed < 1) {
+        throw new Response("Invalid votingAllowed", { status: 422 });
+      }
+      return updateBoardSettingsServer(boardId, votingEnabled, votingAllowed);
+    }
+
+    case "POST": {
+      // Clear all votes/likes — called when enabling voting to wipe existing likes
+      await requireOwner(request, boardId);
+      await clearBoardVotesServer(boardId);
+      return getBoardServer(boardId);
+    }
+
+    default:
+      throw new Response("Method Not Allowed", { status: 405 });
+  }
+}

--- a/app/routes/app/board.tsx
+++ b/app/routes/app/board.tsx
@@ -6,10 +6,11 @@ import { type LoaderFunctionArgs } from "react-router";
 import { BoardProvider } from "~/context/BoardContext";
 import Board from "~/components/Board";
 import { getBoardServer, stopTimerServer } from "~/server/board_model";
+import { getOptionalUser } from "~/hooks/useAuth";
 import { exampleBoardTutorial } from "~/example-data/example_board_tutorial";
 import { exampleBoardRealWorld } from "~/example-data/real_ai_example";
 
-export async function loader({ params }: LoaderFunctionArgs) {
+export async function loader({ request, params }: LoaderFunctionArgs) {
   const { id: board_id } = params;
 
   if (!board_id) {
@@ -20,7 +21,8 @@ export async function loader({ params }: LoaderFunctionArgs) {
   if (board_id === "example-board") return exampleBoardTutorial;
   if (board_id === "example-board-real-world") return exampleBoardRealWorld;
 
-  const board = await getBoardServer(board_id);
+  const user = await getOptionalUser(request);
+  const board = await getBoardServer(board_id, user?.id);
 
   if (!board) {
     throw new Response("Board Not Found", { status: 404 });

--- a/app/routes/app/dashboard.tsx
+++ b/app/routes/app/dashboard.tsx
@@ -81,10 +81,15 @@ export default function AppDashboard() {
     <div className="px-8 mx-auto w-full sm:w-[80%]">
       <h1 className="text-3xl font-semibold">Dashboard</h1>
       <WelcomeBanner
-        id={`${pkg.version}-welcome`}
+        id={`initial-welcome`}
         title="Welcome to your Retrograde dashboard!"
-        message="This is where you can create new boards, view all the boards you have access to, and claim anonymous boards you may have already created.  We've also fixed some bugs and made various improvements."
-        link="https://github.com/Sutherlandon/retrograde/releases/tag/v1.2.0"
+        message="This is where you can create new boards, view all the boards you have access to, and claim anonymous boards you may have already created. We will also make announcements here anytime we release a new version."
+      />
+      <WelcomeBanner
+        id={`${pkg.version}-release`}
+        title={`Version ${pkg.version} Released`}
+        message="This release includes several new features a voting system instead of just likes, the ability to duplicate boards, and more. Check out the release notes for all the details!"
+        link="https://github.com/Sutherlandon/retrograde/releases"
       />
 
       {boards.length === 0 ? (

--- a/app/routes/site/contact.tsx
+++ b/app/routes/site/contact.tsx
@@ -35,53 +35,53 @@ export default function ContactPage() {
 
   return (
     <main className="mx-auto max-w-3xl px-6 py-16">
-        <h1>Get in touch</h1>
-        <p>
-          We’d love to hear from you. Whether you have feedback, a question,
-          or just want to start a conversation, don’t hesitate to reach out.
-        </p>
+      <h1>Get in touch</h1>
+      <p>
+        We’d love to hear from you. Whether you have feedback, a question,
+        or just want to start a conversation, don’t hesitate to reach out.
+      </p>
 
-        <p>
-          We read every message and do our best to respond quickly and
-          thoughtfully. Clear communication and fast follow-ups are important
-          to us.
-        </p>
+      <p>
+        We read every message and do our best to respond quickly and
+        thoughtfully. Clear communication and fast follow-ups are important
+        to us.
+      </p>
 
-        <p>The best way to reach us is by email:</p>
+      <p>The best way to reach us is by email:</p>
 
-        <div className="flex items-center gap-3 flex-wrap mb-6">
-          <div className="text-2xl rounded-lg rounded px-4 py-2 bg-slate-950">
-            hi@retrograde.sh
-          </div>
-
-          <div className="flex items-center gap-3">
-            <Button
-              aria-label="Copy email address to clipboard"
-              text="Email"
-              as="a"
-              href={`mailto:${email}`}
-              variant="outline"
-            />
-
-            <Button
-              onClick={handleCopy}
-              aria-label="Copy email address to clipboard"
-              variant="outline"
-              text="Copy"
-            />
-
-            {copied && (
-              <span className="text-sm font-medium text-green-600">
-                Copied to clipboard!
-              </span>
-            )}
-          </div>
+      <div className="flex items-center gap-3 flex-wrap mb-6">
+        <div className="text-2xl rounded-lg rounded px-4 py-2 bg-slate-200 dark:bg-slate-950">
+          hi@retrograde.sh
         </div>
 
-        <p>
-          We’re based in Northern New Mexico and work with individuals and teams
-          everywhere.
-        </p>
+        <div className="flex items-center gap-3">
+          <Button
+            aria-label="Copy email address to clipboard"
+            text="Email"
+            as="a"
+            href={`mailto:${email}`}
+            variant="outline"
+          />
+
+          <Button
+            onClick={handleCopy}
+            aria-label="Copy email address to clipboard"
+            variant="outline"
+            text="Copy"
+          />
+
+          {copied && (
+            <span className="text-sm font-medium text-green-600">
+              Copied to clipboard!
+            </span>
+          )}
+        </div>
+      </div>
+
+      <p>
+        We’re based in Northern New Mexico and work with individuals and teams
+        everywhere.
+      </p>
     </main>
   );
 }

--- a/app/server/board.types.ts
+++ b/app/server/board.types.ts
@@ -12,6 +12,8 @@ export interface NoteDTO {
   column_id: string;
   text: string;
   likes: number;
+  votes?: number;
+  user_voted?: boolean;
   is_new: boolean;
   created: string;
   note_order: number;
@@ -29,9 +31,12 @@ export interface BoardDTO {
   id: string;
   title: string;
   readonly: boolean;       // true for example boards — server sets this
+  isOwner?: boolean;       // true when the current user is the board owner
   timerRunning: boolean;
   timerStartedAt: string | null;
   timerEndsAt: string | null;
+  votingEnabled?: boolean;
+  votingAllowed?: number;
   columns: ColumnDTO[];
 }
 
@@ -50,6 +55,7 @@ export interface BoardClientState {
   id: string;
   title: string;
   readonly: boolean;
+  isOwner: boolean;
   columns: Column[];
   // Derived on client from columns — NOT from the server
   nextColOrder: number;
@@ -59,6 +65,9 @@ export interface BoardClientState {
   timeLeft: number | null;          // seconds remaining, ticked by interval
   // Network status
   offline: boolean;
+  // Voting
+  votingEnabled: boolean;
+  votingAllowed: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -75,6 +84,8 @@ export interface BoardActions {
   addNote: (columnId: string) => void;
   updateNote: (columnId: string, noteId: string, newText: string, likes: number, created: string) => void;
   likeNote: (noteId: string, delta: number) => void;
+  voteNote: (noteId: string) => void;
+  updateBoardSettings: (votingEnabled: boolean, votingAllowed: number) => void;
   deleteNote: (columnId: string, noteId: string, text?: string) => void;
   moveNote: (fromColumnId: string, toColumnId: string, noteId: string) => void;
   reorderNote: (fromColumnId: string, toColumnId: string, noteId: string, newIndex: number) => void;

--- a/app/server/board_model.test.ts
+++ b/app/server/board_model.test.ts
@@ -51,8 +51,11 @@ describe("duplicateBoardServer", () => {
 
     // BEGIN
     mockQuery.mockResolvedValueOnce({});
-    // SELECT title
-    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ title: "Sprint 1" }] });
+    // SELECT title + voting settings
+    mockQuery.mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ title: "Sprint 1", voting_enabled: true, voting_allowed: 3 }],
+    });
     // INSERT board
     mockQuery.mockResolvedValueOnce({});
     // INSERT board_member
@@ -82,6 +85,10 @@ describe("duplicateBoardServer", () => {
     expect(insertBoardCall[0]).toContain("INSERT INTO boards");
     expect(insertBoardCall[1][1]).toBe("Sprint 1 (copy)");
 
+    // Verify voting settings were copied
+    expect(insertBoardCall[1][3]).toBe(true);  // voting_enabled
+    expect(insertBoardCall[1][4]).toBe(3);     // voting_allowed
+
     // Verify owner membership
     const insertMemberCall = mockQuery.mock.calls[3];
     expect(insertMemberCall[0]).toContain("INSERT INTO board_members");
@@ -110,6 +117,80 @@ describe("duplicateBoardServer", () => {
 
     await expect(duplicateBoardServer("bad-id", "user-1")).rejects.toThrow("Board not found");
     expect(mockRelease).toHaveBeenCalled();
+  });
+});
+
+describe("updateBoardSettingsServer", () => {
+  it("enables voting with a specified allowed vote count", async () => {
+    const { updateBoardSettingsServer } = await import("./board_model");
+
+    mockPoolQuery.mockResolvedValueOnce({}); // UPDATE boards
+    mockPoolQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ board: { id: "board-1", columns: [] } }] }); // getBoardServer
+
+    await updateBoardSettingsServer("board-1", true, 3);
+
+    expect(mockPoolQuery.mock.calls[0][0]).toContain("UPDATE boards");
+    expect(mockPoolQuery.mock.calls[0][0]).toContain("voting_enabled");
+    expect(mockPoolQuery.mock.calls[0][0]).toContain("voting_allowed");
+    expect(mockPoolQuery.mock.calls[0][1]).toEqual([true, 3, "board-1"]);
+  });
+
+  it("disables voting", async () => {
+    const { updateBoardSettingsServer } = await import("./board_model");
+
+    mockPoolQuery.mockResolvedValueOnce({});
+    mockPoolQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ board: { id: "board-1", columns: [] } }] });
+
+    await updateBoardSettingsServer("board-1", false, 5);
+
+    expect(mockPoolQuery.mock.calls[0][1]).toEqual([false, 5, "board-1"]);
+  });
+});
+
+describe("clearBoardVotesServer", () => {
+  it("clears all likes and votes for every note on the board", async () => {
+    const { clearBoardVotesServer } = await import("./board_model");
+
+    mockPoolQuery.mockResolvedValueOnce({}); // DELETE note_votes
+    mockPoolQuery.mockResolvedValueOnce({}); // UPDATE notes SET likes = 0
+
+    await clearBoardVotesServer("board-1");
+
+    expect(mockPoolQuery.mock.calls[0][0]).toContain("DELETE FROM note_votes");
+    expect(mockPoolQuery.mock.calls[1][0]).toContain("UPDATE notes SET likes = 0");
+  });
+});
+
+describe("voteNoteServer", () => {
+  it("inserts a vote row when the user has not yet voted on the note", async () => {
+    const { voteNoteServer } = await import("./board_model");
+
+    // INSERT vote (ON CONFLICT DO NOTHING returns rowCount 1)
+    mockPoolQuery.mockResolvedValueOnce({ rowCount: 1 });
+    // getBoardServer
+    mockPoolQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ board: { id: "board-1", columns: [] } }] });
+
+    await voteNoteServer("board-1", "note-1", "user-1");
+
+    expect(mockPoolQuery.mock.calls[0][0]).toContain("INSERT INTO note_votes");
+    expect(mockPoolQuery.mock.calls[0][1]).toContain("note-1");
+    expect(mockPoolQuery.mock.calls[0][1]).toContain("user-1");
+  });
+
+  it("removes the vote row when the user has already voted on the note", async () => {
+    const { voteNoteServer } = await import("./board_model");
+
+    // INSERT returns rowCount 0 (conflict — vote already exists)
+    mockPoolQuery.mockResolvedValueOnce({ rowCount: 0 });
+    // DELETE
+    mockPoolQuery.mockResolvedValueOnce({});
+    // getBoardServer
+    mockPoolQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ board: { id: "board-1", columns: [] } }] });
+
+    await voteNoteServer("board-1", "note-1", "user-1");
+
+    expect(mockPoolQuery.mock.calls[1][0]).toContain("DELETE FROM note_votes");
+    expect(mockPoolQuery.mock.calls[1][1]).toEqual(["note-1", "user-1"]);
   });
 });
 

--- a/app/server/board_model.ts
+++ b/app/server/board_model.ts
@@ -10,16 +10,23 @@ import type { BoardDTO } from "./board.types";
 // READ
 // ---------------------------------------------------------------------------
 
-export async function getBoardServer(id: string): Promise<BoardDTO | null> {
+export async function getBoardServer(id: string, userId?: string | null): Promise<BoardDTO | null> {
   const res = await pool.query(
     `
     SELECT json_build_object(
       'id',             b.id,
       'title',          b.title,
       'readonly',       false,
+      'isOwner',        CASE
+                          WHEN $2::uuid IS NOT NULL
+                          THEN EXISTS(SELECT 1 FROM board_members bm WHERE bm.board_id = b.id AND bm.user_id = $2::uuid AND bm.role = 'owner')
+                          ELSE FALSE
+                        END,
       'timerRunning',   b.timer_running,
       'timerStartedAt', to_char(b.timer_started_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
       'timerEndsAt',    to_char(b.timer_ends_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+      'votingEnabled',  b.voting_enabled,
+      'votingAllowed',  b.voting_allowed,
       'columns', COALESCE(
         json_agg(
           json_build_object(
@@ -34,6 +41,12 @@ export async function getBoardServer(id: string): Promise<BoardDTO | null> {
                     'id',         n.id,
                     'text',       n.text,
                     'likes',      n.likes,
+                    'votes',      (SELECT COUNT(*) FROM note_votes nv WHERE nv.note_id = n.id),
+                    'user_voted', CASE
+                                    WHEN $2::uuid IS NOT NULL
+                                    THEN EXISTS(SELECT 1 FROM note_votes nv WHERE nv.note_id = n.id AND nv.user_id = $2::uuid)
+                                    ELSE FALSE
+                                  END,
                     'is_new',     n.is_new,
                     'created',    n.created,
                     'note_order', n.note_order
@@ -56,7 +69,7 @@ export async function getBoardServer(id: string): Promise<BoardDTO | null> {
     WHERE b.id = $1
     GROUP BY b.id
     `,
-    [id]
+    [id, userId ?? null]
   );
 
   if (res.rowCount === 0) return null;
@@ -176,6 +189,42 @@ export async function likeNoteServer(boardId: string, noteId: string, delta: num
   return getBoardServer(boardId);
 }
 
+export async function voteNoteServer(boardId: string, noteId: string, userId: string) {
+  // Try to insert. If the row already exists (user already voted), delete it instead.
+  const insert = await pool.query(
+    `INSERT INTO note_votes (note_id, user_id) VALUES ($1, $2) ON CONFLICT (note_id, user_id) DO NOTHING`,
+    [noteId, userId]
+  );
+  if (insert.rowCount === 0) {
+    // Vote existed — remove it (toggle off)
+    await pool.query(`DELETE FROM note_votes WHERE note_id = $1 AND user_id = $2`, [noteId, userId]);
+  }
+  return getBoardServer(boardId, userId);
+}
+
+export async function updateBoardSettingsServer(
+  boardId: string,
+  votingEnabled: boolean,
+  votingAllowed: number
+) {
+  await pool.query(
+    `UPDATE boards SET voting_enabled = $1, voting_allowed = $2 WHERE id = $3`,
+    [votingEnabled, votingAllowed, boardId]
+  );
+  return getBoardServer(boardId);
+}
+
+export async function clearBoardVotesServer(boardId: string) {
+  await pool.query(
+    `DELETE FROM note_votes WHERE note_id IN (SELECT n.id FROM notes n JOIN columns c ON c.id = n.column_id WHERE c.board_id = $1)`,
+    [boardId]
+  );
+  await pool.query(
+    `UPDATE notes SET likes = 0 WHERE column_id IN (SELECT id FROM columns WHERE board_id = $1)`,
+    [boardId]
+  );
+}
+
 export async function deleteNoteServer(boardId: string, columnId: string, noteId: string) {
   await pool.query(`DELETE FROM notes WHERE id = $1`, [noteId]);
   return getBoardServer(boardId);
@@ -268,18 +317,19 @@ export async function duplicateBoardServer(
   try {
     await client.query("BEGIN");
 
-    // Get the original board title
+    // Get the original board title and settings
     const boardRes = await client.query(
-      `SELECT title FROM boards WHERE id = $1`,
+      `SELECT title, voting_enabled, voting_allowed FROM boards WHERE id = $1`,
       [boardId]
     );
     if (boardRes.rowCount === 0) throw new Error("Board not found");
-    const newTitle = `${boardRes.rows[0].title} (copy)`;
+    const { title, voting_enabled, voting_allowed } = boardRes.rows[0];
+    const newTitle = `${title} (copy)`;
 
-    // Create the new board
+    // Create the new board (copy voting settings)
     await client.query(
-      `INSERT INTO boards (id, title, created_by) VALUES ($1, $2, $3)`,
-      [newId, newTitle, userId]
+      `INSERT INTO boards (id, title, created_by, voting_enabled, voting_allowed) VALUES ($1, $2, $3, $4, $5)`,
+      [newId, newTitle, userId, voting_enabled, voting_allowed]
     );
 
     // Add the user as owner

--- a/app/server/db_init.ts
+++ b/app/server/db_init.ts
@@ -146,6 +146,26 @@ export async function initializeDatabase() {
       ADD COLUMN IF NOT EXISTS prompt TEXT NOT NULL DEFAULT '';
     `);
 
+    // 8 Add voting settings to boards
+    await client.query(`
+      ALTER TABLE boards
+      ADD COLUMN IF NOT EXISTS voting_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+      ADD COLUMN IF NOT EXISTS voting_allowed INTEGER NOT NULL DEFAULT 5;
+    `);
+
+    // 9 Create note_votes table to track who voted on which note
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS note_votes (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        note_id TEXT NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
+        user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+        UNIQUE(note_id, user_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_note_votes_note_id ON note_votes(note_id);
+      CREATE INDEX IF NOT EXISTS idx_note_votes_user_id ON note_votes(user_id);
+    `);
+
     console.log("Done");
     console.log("Inserting dev data...");
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0",
+  "version": "1.5.0",
   "name": "retrograde",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Voting system (closes #16):
- Board owners can enable a voting system from a new settings modal (gear icon at end of toolbar), replacing the like button with a tracked vote counter per user
- Votes are stored in a new note_votes table so the system knows who voted on each note; clicking a voted note toggles the vote off
- A "votes remaining" counter in the toolbar enforces the configurable per-person vote limit across the board
- Enabling voting clears all existing likes after a warning; duplicating a board copies its voting settings
- Only logged-in users can cast votes; anonymous users see counts but cannot vote
- Board settings (voting toggle + vote count) are owner-only; server enforces this with a 403

Dashboard and UI polish:
- Split the dashboard welcome banner into a persistent intro message and a per-release announcement banner; release notes link now points to all releases
- WelcomeBanner link is now optional so the intro message needs no button
- Contact page email address now uses a grey background in light mode for legibility