### PR TITLE
Add board attachments feature (#45)

### DIFF
--- a/app/components/AttachmentModal.tsx
+++ b/app/components/AttachmentModal.tsx
@@ -1,0 +1,316 @@
+import { useEffect, useRef, useState } from "react";
+import { useBoard } from "~/context/BoardContext";
+import { CloseIcon, ImageIcon } from "~/images/icons";
+
+interface AttachmentModalProps {
+  onClose: () => void;
+}
+
+type AttachmentMode = "link" | "image";
+
+const MAX_IMAGE_SIZE = 250_000; // 250KB
+
+/**
+ * Compress an image file to fit within maxBytes by reducing quality and
+ * dimensions. Returns a base64 data URL.
+ */
+async function compressImage(file: File, maxBytes: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        let quality = 0.8;
+        let scale = 1;
+
+        const tryCompress = (): string => {
+          const canvas = document.createElement("canvas");
+          canvas.width = Math.round(img.width * scale);
+          canvas.height = Math.round(img.height * scale);
+          const ctx = canvas.getContext("2d");
+          if (!ctx) throw new Error("Could not get canvas context");
+          ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+          return canvas.toDataURL("image/jpeg", quality);
+        };
+
+        // Iteratively reduce quality and size
+        let result = tryCompress();
+        let attempts = 0;
+        while (result.length > maxBytes && attempts < 20) {
+          if (quality > 0.1) {
+            quality -= 0.1;
+          } else {
+            scale *= 0.7;
+          }
+          result = tryCompress();
+          attempts++;
+        }
+
+        if (result.length > maxBytes) {
+          reject(new Error("Could not compress image to fit within size limit"));
+        } else {
+          resolve(result);
+        }
+      };
+      img.onerror = () => reject(new Error("Failed to load image"));
+      img.src = reader.result as string;
+    };
+    reader.onerror = () => reject(new Error("Failed to read file"));
+    reader.readAsDataURL(file);
+  });
+}
+
+export function AttachmentModal({ onClose }: AttachmentModalProps) {
+  const { addLinkAttachment, addImageAttachment, attachments } = useBoard();
+  const [mode, setMode] = useState<AttachmentMode>("link");
+  const [filename, setFilename] = useState("");
+  const [link, setLink] = useState("");
+  const [imageData, setImageData] = useState<string | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [compressing, setCompressing] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const filenameRef = useRef<HTMLInputElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const imageCount = attachments.filter((a) => a.type === "image").length;
+
+  // Focus filename on open
+  useEffect(() => {
+    filenameRef.current?.focus();
+  }, []);
+
+  // Close on outside click
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [onClose]);
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  async function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (!file.type.startsWith("image/")) {
+      setError("Only image files are supported for upload");
+      return;
+    }
+
+    if (imageCount >= 5) {
+      setError("Maximum of 5 uploaded images per board");
+      return;
+    }
+
+    setError(null);
+    setCompressing(true);
+
+    try {
+      const compressed = await compressImage(file, MAX_IMAGE_SIZE);
+      setImageData(compressed);
+      setImagePreview(compressed);
+      if (!filename) {
+        setFilename(file.name);
+      }
+    } catch {
+      setError("Could not compress image to fit within size limit. Try a smaller image.");
+    } finally {
+      setCompressing(false);
+    }
+  }
+
+  function handleSave() {
+    const trimmedFilename = filename.trim();
+    if (!trimmedFilename) {
+      setError("Filename is required");
+      return;
+    }
+
+    if (mode === "link") {
+      const trimmedLink = link.trim();
+      if (!trimmedLink) {
+        setError("Link is required");
+        return;
+      }
+      addLinkAttachment(trimmedFilename, trimmedLink);
+    } else {
+      if (!imageData) {
+        setError("Please select an image to upload");
+        return;
+      }
+      addImageAttachment(trimmedFilename, imageData);
+    }
+
+    onClose();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div
+        ref={modalRef}
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-md mx-4 p-6"
+      >
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-lg font-semibold">Add Attachment</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+          >
+            <CloseIcon size="md" />
+          </button>
+        </div>
+
+        {/* Mode toggle */}
+        <div className="flex gap-2 mb-4">
+          <button
+            type="button"
+            onClick={() => { setMode("link"); setError(null); }}
+            className={`px-3 py-1.5 text-sm rounded cursor-pointer transition-colors ${
+              mode === "link"
+                ? "bg-blue-600 text-white"
+                : "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600"
+            }`}
+          >
+            Link
+          </button>
+          <button
+            type="button"
+            onClick={() => { setMode("image"); setError(null); }}
+            className={`px-3 py-1.5 text-sm rounded cursor-pointer transition-colors ${
+              mode === "image"
+                ? "bg-blue-600 text-white"
+                : "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600"
+            }`}
+          >
+            Image Upload
+          </button>
+        </div>
+
+        <div className="space-y-4" onKeyDown={handleKeyDown}>
+          {/* Filename — hidden when image tab is at limit */}
+          {!(mode === "image" && imageCount >= 5) && (
+            <div>
+              <label htmlFor="attachment-filename" className="block text-sm font-medium mb-1">
+                Filename
+              </label>
+              <input
+                ref={filenameRef}
+                id="attachment-filename"
+                type="text"
+                value={filename}
+                onChange={(e) => setFilename(e.target.value)}
+                placeholder="e.g. sprint-review.pdf"
+                className="w-full border border-gray-300 dark:border-gray-600 rounded px-3 py-2 text-sm bg-white dark:bg-gray-700"
+              />
+            </div>
+          )}
+
+          {mode === "link" ? (
+            /* Link input */
+            <div>
+              <label htmlFor="attachment-link" className="block text-sm font-medium mb-1">
+                Link
+              </label>
+              <input
+                id="attachment-link"
+                type="url"
+                value={link}
+                onChange={(e) => setLink(e.target.value)}
+                placeholder="https://..."
+                className="w-full border border-gray-300 dark:border-gray-600 rounded px-3 py-2 text-sm bg-white dark:bg-gray-700"
+              />
+            </div>
+          ) : imageCount >= 5 ? (
+            /* Image limit reached */
+            <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 text-center">
+              <p className="text-sm mb-1">
+                You've used <strong>5/5</strong> image uploads.
+              </p>
+              <p className="text-xs">
+                Delete an existing image to upload a new one, or attach it as a link instead.
+              </p>
+            </div>
+          ) : (
+            /* Image upload */
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Image ({imageCount}/5 used)
+              </label>
+              <div
+                className="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-4 text-center cursor-pointer hover:border-blue-400 dark:hover:border-blue-500 transition-colors"
+                onClick={() => fileInputRef.current?.click()}
+              >
+                {imagePreview ? (
+                  <img
+                    src={imagePreview}
+                    alt="Preview"
+                    className="max-h-32 mx-auto rounded"
+                  />
+                ) : compressing ? (
+                  <p className="text-sm text-gray-500 dark:text-gray-400">Compressing...</p>
+                ) : (
+                  <div className="flex flex-col items-center gap-2 text-gray-500 dark:text-gray-400">
+                    <ImageIcon size="xl" />
+                    <p className="text-sm">Click to select an image</p>
+                  </div>
+                )}
+              </div>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                onChange={handleFileSelect}
+                className="hidden"
+              />
+            </div>
+          )}
+
+          {error && (
+            <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 mt-6">
+          {!(mode === "image" && imageCount >= 5) && (
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={compressing}
+              className="px-4 py-2 text-sm rounded bg-blue-600 text-white hover:bg-blue-700 transition-colors cursor-pointer disabled:opacity-50"
+            >
+              Save
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+          >
+            {mode === "image" && imageCount >= 5 ? "Close" : "Abort"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/AttachmentsList.tsx
+++ b/app/components/AttachmentsList.tsx
@@ -1,0 +1,261 @@
+import { useState } from "react";
+import { useBoard } from "~/context/BoardContext";
+import { CloseIcon } from "~/images/icons";
+import type { Attachment } from "~/server/board.types";
+
+// ---------------------------------------------------------------------------
+// File-type icon colors and labels derived from filename extension
+// ---------------------------------------------------------------------------
+
+interface FileTypeInfo {
+  label: string;
+  bgColor: string;
+  textColor: string;
+}
+
+function getFileTypeInfo(filename: string): FileTypeInfo {
+  const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+
+  switch (ext) {
+    case "pdf":
+      return { label: "PDF", bgColor: "bg-red-500", textColor: "text-white" };
+    case "doc":
+    case "docx":
+      return { label: "DOC", bgColor: "bg-blue-600", textColor: "text-white" };
+    case "xls":
+    case "xlsx":
+      return { label: "XLS", bgColor: "bg-green-600", textColor: "text-white" };
+    case "md":
+    case "markdown":
+      return { label: "MD", bgColor: "bg-purple-600", textColor: "text-white" };
+    default:
+      return { label: "FILE", bgColor: "bg-gray-500", textColor: "text-white" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// File icon component
+// ---------------------------------------------------------------------------
+
+function FileTypeIcon({ filename }: { filename: string }) {
+  const { label, bgColor, textColor } = getFileTypeInfo(filename);
+  return (
+    <div
+      className={`${bgColor} ${textColor} w-10 h-10 rounded flex items-center justify-center text-xs font-bold shrink-0`}
+    >
+      {label}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Confirm delete dialog
+// ---------------------------------------------------------------------------
+
+function ConfirmDeleteDialog({
+  filename,
+  onConfirm,
+  onCancel,
+}: {
+  filename: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-sm mx-4 p-6">
+        <h3 className="text-sm font-semibold mb-2">Delete Attachment</h3>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+          Are you sure you want to delete <strong>{filename}</strong>? This cannot be undone.
+        </p>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="px-3 py-1.5 text-sm rounded bg-red-600 text-white hover:bg-red-700 transition-colors cursor-pointer"
+          >
+            Delete
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-3 py-1.5 text-sm rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Image preview modal
+// ---------------------------------------------------------------------------
+
+function ImagePreviewModal({
+  filename,
+  imageData,
+  onClose,
+}: {
+  filename: string;
+  imageData: string;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-3xl max-h-[90vh] mx-4 flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+          <h3 className="text-sm font-semibold truncate">{filename}</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer shrink-0 ml-4"
+          >
+            <CloseIcon size="md" />
+          </button>
+        </div>
+        <div className="p-4 overflow-auto">
+          <img
+            src={imageData}
+            alt={filename}
+            className="max-w-full max-h-[75vh] mx-auto rounded"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Single attachment row
+// ---------------------------------------------------------------------------
+
+function AttachmentItem({
+  attachment,
+  isOwner,
+  onDelete,
+  onImageClick,
+}: {
+  attachment: Attachment;
+  isOwner: boolean;
+  onDelete: (id: string) => void;
+  onImageClick: (attachment: Attachment) => void;
+}) {
+  const isImage = attachment.type === "image" && attachment.image_data;
+
+  const content = (
+    <>
+      {/* Icon or thumbnail */}
+      {isImage ? (
+        <img
+          src={attachment.image_data!}
+          alt={attachment.filename}
+          className="w-10 h-10 rounded object-cover shrink-0"
+        />
+      ) : (
+        <FileTypeIcon filename={attachment.filename} />
+      )}
+
+      {/* Filename */}
+      <span className="text-sm truncate flex-1">{attachment.filename}</span>
+
+      {/* Delete button (owner only, visible on hover) */}
+      {isOwner && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onDelete(attachment.id);
+          }}
+          className="opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-red-100 dark:hover:bg-red-900/40 text-red-500 transition-all cursor-pointer"
+          title="Delete attachment"
+        >
+          <CloseIcon size="sm" />
+        </button>
+      )}
+    </>
+  );
+
+  if (isImage) {
+    return (
+      <button
+        type="button"
+        onClick={() => onImageClick(attachment)}
+        className="group flex items-center gap-3 p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer text-left w-full"
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <a
+      href={attachment.link ?? "#"}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group flex items-center gap-3 p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+    >
+      {content}
+    </a>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main attachments list
+// ---------------------------------------------------------------------------
+
+export function AttachmentsList() {
+  const { attachments, isOwner, deleteAttachment } = useBoard();
+  const [deleteTarget, setDeleteTarget] = useState<Attachment | null>(null);
+  const [previewImage, setPreviewImage] = useState<Attachment | null>(null);
+
+  if (attachments.length === 0) return null;
+
+  function handleConfirmDelete() {
+    if (deleteTarget) {
+      deleteAttachment(deleteTarget.id);
+      setDeleteTarget(null);
+    }
+  }
+
+  return (
+    <div className="mt-8">
+      <h2 className="text-lg font-semibold mb-3">Attachments</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-1">
+        {attachments.map((attachment) => (
+          <AttachmentItem
+            key={attachment.id}
+            attachment={attachment}
+            isOwner={isOwner}
+            onDelete={() => setDeleteTarget(attachment)}
+            onImageClick={setPreviewImage}
+          />
+        ))}
+      </div>
+
+      {deleteTarget && (
+        <ConfirmDeleteDialog
+          filename={deleteTarget.filename}
+          onConfirm={handleConfirmDelete}
+          onCancel={() => setDeleteTarget(null)}
+        />
+      )}
+
+      {previewImage && previewImage.image_data && (
+        <ImagePreviewModal
+          filename={previewImage.filename}
+          imageData={previewImage.image_data}
+          onClose={() => setPreviewImage(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/components/Board.tsx
+++ b/app/components/Board.tsx
@@ -16,6 +16,7 @@ import { useBoard } from "../context/BoardContext";
 import BoardToolbar from "./BoardToolbar";
 import Column from "./Column";
 import TimerEndModal from "./TimerEndModal";
+import { AttachmentsList } from "./AttachmentsList";
 
 const noteColors = [
   'bg-yellow-200',
@@ -175,6 +176,7 @@ export default function Board() {
           ) : null}
         </DragOverlay>
       </DndContext>
+      <AttachmentsList />
       <TimerEndModal
         isOpen={showTimerEndModal}
         onClose={() => setShowTimerEndModal(false)}

--- a/app/components/BoardToolbar.tsx
+++ b/app/components/BoardToolbar.tsx
@@ -3,15 +3,17 @@ import TimerButton from "./TimerButton";
 import ExportButton from "./ExportButton";
 import Button from "./Button";
 import { useBoard } from "~/context/BoardContext";
-import { EditIcon, PlusIcon, SettingsIcon } from "~/images/icons";
+import { EditIcon, PaperclipIcon, PlusIcon, SettingsIcon } from "~/images/icons";
 import TimerDisplay from "./TimerDisplay";
 import { BoardSettingsModal } from "./BoardSettingsModal";
+import { AttachmentModal } from "./AttachmentModal";
 
 export default function BoardToolbar({ title }: { title: string }) {
   const { addColumn, updateTitle, isOwner, votingEnabled, votingAllowed, columns } = useBoard();
   const [editing, setEditing] = useState(false);
   const [localTitle, setLocalTitle] = useState(title);
   const [showSettings, setShowSettings] = useState(false);
+  const [showAttachments, setShowAttachments] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Keep local state in sync if server pushes a new title (multi-user)
@@ -78,6 +80,13 @@ export default function BoardToolbar({ title }: { title: string }) {
         )}
         <TimerButton />
         <ExportButton />
+        {isOwner && (
+          <Button
+            icon={<PaperclipIcon />}
+            text="Attach"
+            onClick={() => setShowAttachments(true)}
+          />
+        )}
         <Button
           icon={<PlusIcon />}
           text="Column"
@@ -94,6 +103,9 @@ export default function BoardToolbar({ title }: { title: string }) {
       </div>
       {showSettings && (
         <BoardSettingsModal onClose={() => setShowSettings(false)} />
+      )}
+      {showAttachments && (
+        <AttachmentModal onClose={() => setShowAttachments(false)} />
       )}
     </>
   );

--- a/app/context/BoardContext.tsx
+++ b/app/context/BoardContext.tsx
@@ -5,7 +5,7 @@
 import { createContext, useContext, useState, useEffect, useRef } from "react";
 import { useFetcher, useLoaderData } from "react-router";
 import { nanoid } from "nanoid";
-import type { Board, BoardDTO, Column, Note } from "~/server/board.types";
+import type { Attachment, Board, BoardDTO, Column, Note } from "~/server/board.types";
 
 // ---------------------------------------------------------------------------
 // Context setup
@@ -98,6 +98,8 @@ export function BoardProvider({ children }: { children: React.ReactNode }) {
   const [offline, setOffline] = useState(false);
   const [votingEnabled, setVotingEnabled] = useState(loaderData.votingEnabled ?? false);
   const [votingAllowed, setVotingAllowed] = useState(loaderData.votingAllowed ?? 5);
+  const [attachments, setAttachments] = useState<Attachment[]>(loaderData.attachments ?? []);
+  const attachmentFetcher = useFetcher();
   const isOwner = loaderData.isOwner ?? false;
 
   // ---------------------------------------------------------------------------
@@ -137,6 +139,12 @@ export function BoardProvider({ children }: { children: React.ReactNode }) {
   }, [noteFetcher.data]);
 
   useEffect(() => {
+    if (attachmentFetcher.data) {
+      setAttachments(attachmentFetcher.data as Attachment[]);
+    }
+  }, [attachmentFetcher.data]);
+
+  useEffect(() => {
     if (settingsFetcher.data) {
       const data = settingsFetcher.data as BoardDTO;
       setColumns(data.columns as Column[]);
@@ -172,6 +180,7 @@ export function BoardProvider({ children }: { children: React.ReactNode }) {
         setTitle(data.title);
         setVotingEnabled(data.votingEnabled ?? false);
         setVotingAllowed(data.votingAllowed ?? 5);
+        if (data.attachments) setAttachments(data.attachments);
 
         syncTimerState(data, timerRunning, timerEndsAt, setTimerRunning, setTimerEndsAt);
       } catch (err) {
@@ -460,6 +469,35 @@ export function BoardProvider({ children }: { children: React.ReactNode }) {
   };
 
   // ---------------------------------------------------------------------------
+  // Attachment actions
+  // ---------------------------------------------------------------------------
+
+  const addLinkAttachment = (filename: string, link: string) => {
+    if (isReadOnly) return;
+    attachmentFetcher.submit(
+      { type: "link", filename, link },
+      { method: "POST", action: `/app/board/${boardId}/attachments` }
+    );
+  };
+
+  const addImageAttachment = (filename: string, imageData: string) => {
+    if (isReadOnly) return;
+    attachmentFetcher.submit(
+      { type: "image", filename, imageData },
+      { method: "POST", action: `/app/board/${boardId}/attachments` }
+    );
+  };
+
+  const deleteAttachment = (attachmentId: string) => {
+    if (isReadOnly) return;
+    setAttachments((prev) => prev.filter((a) => a.id !== attachmentId));
+    attachmentFetcher.submit(
+      { attachmentId },
+      { method: "DELETE", action: `/app/board/${boardId}/attachments` }
+    );
+  };
+
+  // ---------------------------------------------------------------------------
   // Timer actions
   // ---------------------------------------------------------------------------
 
@@ -519,6 +557,10 @@ export function BoardProvider({ children }: { children: React.ReactNode }) {
     moveNote,
     reorderNote,
     moveNoteLocally,
+    attachments,
+    addLinkAttachment,
+    addImageAttachment,
+    deleteAttachment,
     startTimer,
     stopTimer,
   };

--- a/app/images/icons.tsx
+++ b/app/images/icons.tsx
@@ -629,6 +629,63 @@ export function SettingsIcon({ size = 'md', className = '' }: IconProps) {
   );
 }
 
+export function PaperclipIcon({ size = 'md', className = '' }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={`${sizeMap[size]} ${className}`}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m18.375 12.739-7.693 7.693a4.5 4.5 0 0 1-6.364-6.364l10.94-10.94A3 3 0 1 1 19.5 7.372L8.552 18.32m.009-.01-.01.01m5.699-9.941-7.81 7.81a1.5 1.5 0 0 0 2.112 2.13"
+      />
+    </svg>
+  );
+}
+
+export function FileIcon({ size = 'md', className = '' }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={`${sizeMap[size]} ${className}`}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+      />
+    </svg>
+  );
+}
+
+export function ImageIcon({ size = 'md', className = '' }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={`${sizeMap[size]} ${className}`}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0 0 22.5 18.75V5.25A2.25 2.25 0 0 0 20.25 3H3.75A2.25 2.25 0 0 0 1.5 5.25v13.5A2.25 2.25 0 0 0 3.75 21Z"
+      />
+    </svg>
+  );
+}
+
 export function CloseIcon({ size = 'md', className = '' }: IconProps) {
   return (
     <svg

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -30,6 +30,7 @@ export default [
     route("timer", "routes/app/board.timer.ts"),
     route("poll", "routes/app/board.poll.ts"),
     route("settings", "routes/app/board.settings.ts"),
+    route("attachments", "routes/app/board.attachments.ts"),
   ]),
 
   /* Api Routes */

--- a/app/routes/app/board.attachments.ts
+++ b/app/routes/app/board.attachments.ts
@@ -1,0 +1,81 @@
+// routes/app/board.attachments.ts
+// Resource route — no UI. Handles attachment mutations.
+// GET    → list attachments for a board
+// POST   → add a link or image attachment (owner only)
+// DELETE → remove an attachment (owner only)
+
+import { type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
+import { getOptionalUser } from "~/hooks/useAuth";
+import {
+  getAttachmentsServer,
+  addLinkAttachmentServer,
+  addImageAttachmentServer,
+  deleteAttachmentServer,
+} from "~/server/attachment_model";
+import { pool } from "~/server/db_config";
+
+async function requireOwner(request: Request, boardId: string) {
+  const user = await getOptionalUser(request);
+  if (!user) throw new Response("Unauthorized", { status: 401 });
+
+  const res = await pool.query(
+    `SELECT role FROM board_members WHERE board_id = $1 AND user_id = $2`,
+    [boardId, user.id]
+  );
+  if (res.rowCount === 0 || res.rows[0].role !== "owner") {
+    throw new Response("Forbidden", { status: 403 });
+  }
+  return user;
+}
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const { id: boardId } = params;
+  if (!boardId) throw new Response("Board ID Missing", { status: 400 });
+
+  return Response.json(await getAttachmentsServer(boardId));
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  const { id: boardId } = params;
+  if (!boardId) throw new Response("Board ID Missing", { status: 400 });
+
+  await requireOwner(request, boardId);
+  const data = await request.formData();
+
+  switch (request.method.toUpperCase()) {
+    case "POST": {
+      const type = data.get("type") as string;
+      const filename = data.get("filename") as string;
+
+      if (!filename) throw new Response("Filename is required", { status: 422 });
+
+      if (type === "image") {
+        const imageData = data.get("imageData") as string;
+        if (!imageData) throw new Response("Image data is required", { status: 422 });
+
+        try {
+          return Response.json(await addImageAttachmentServer(boardId, filename, imageData));
+        } catch (err) {
+          const message = (err as Error).message;
+          if (message.includes("Maximum") || message.includes("exceeds")) {
+            throw new Response(message, { status: 422 });
+          }
+          throw err;
+        }
+      } else {
+        const link = data.get("link") as string;
+        if (!link) throw new Response("Link is required", { status: 422 });
+        return Response.json(await addLinkAttachmentServer(boardId, filename, link));
+      }
+    }
+
+    case "DELETE": {
+      const attachmentId = data.get("attachmentId") as string;
+      if (!attachmentId) throw new Response("Attachment ID is required", { status: 422 });
+      return Response.json(await deleteAttachmentServer(boardId, attachmentId));
+    }
+
+    default:
+      throw new Response("Method Not Allowed", { status: 405 });
+  }
+}

--- a/app/routes/app/board.poll.ts
+++ b/app/routes/app/board.poll.ts
@@ -1,6 +1,7 @@
 // routes/app/board.poll.ts
 import { type LoaderFunctionArgs } from "react-router";
 import { getBoardServer, stopTimerServer } from "~/server/board_model";
+import { getAttachmentsServer } from "~/server/attachment_model";
 import { getOptionalUser } from "~/hooks/useAuth";
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
@@ -18,6 +19,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       board.timerEndsAt = null;
     }
   }
+
+  board.attachments = await getAttachmentsServer(boardId);
 
   return Response.json(board);
 }

--- a/app/routes/app/board.tsx
+++ b/app/routes/app/board.tsx
@@ -6,6 +6,7 @@ import { type LoaderFunctionArgs } from "react-router";
 import { BoardProvider } from "~/context/BoardContext";
 import Board from "~/components/Board";
 import { getBoardServer, stopTimerServer } from "~/server/board_model";
+import { getAttachmentsServer } from "~/server/attachment_model";
 import { getOptionalUser } from "~/hooks/useAuth";
 import { exampleBoardTutorial } from "~/example-data/example_board_tutorial";
 import { exampleBoardRealWorld } from "~/example-data/real_ai_example";
@@ -36,6 +37,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       board.timerEndsAt = null;
     }
   }
+
+  board.attachments = await getAttachmentsServer(board_id);
 
   return board;
 }

--- a/app/server/attachment_model.test.ts
+++ b/app/server/attachment_model.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockQuery = vi.fn();
+const mockRelease = vi.fn();
+const mockPoolQuery = vi.fn();
+vi.mock("~/server/db_config", () => ({
+  pool: {
+    query: (...args: unknown[]) => mockPoolQuery(...args),
+    connect: vi.fn(async () => ({
+      query: mockQuery,
+      release: mockRelease,
+    })),
+  },
+}));
+
+vi.mock("~/server/db_init", () => ({}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+});
+
+describe("getAttachmentsServer", () => {
+  it("returns attachments for a board", async () => {
+    const { getAttachmentsServer } = await import("./attachment_model");
+
+    const mockAttachments = [
+      { id: "att-1", board_id: "board-1", filename: "doc.pdf", link: "https://example.com/doc.pdf", type: "link", image_data: null, created_at: "2026-01-01T00:00:00Z" },
+      { id: "att-2", board_id: "board-1", filename: "photo.jpg", link: null, type: "image", image_data: "data:image/jpeg;base64,abc", created_at: "2026-01-02T00:00:00Z" },
+    ];
+
+    mockPoolQuery.mockResolvedValueOnce({ rows: mockAttachments, rowCount: 2 });
+
+    const result = await getAttachmentsServer("board-1");
+
+    expect(mockPoolQuery.mock.calls[0][0]).toContain("SELECT");
+    expect(mockPoolQuery.mock.calls[0][0]).toContain("attachments");
+    expect(mockPoolQuery.mock.calls[0][1]).toEqual(["board-1"]);
+    expect(result).toHaveLength(2);
+    expect(result[0].filename).toBe("doc.pdf");
+  });
+
+  it("returns empty array when no attachments exist", async () => {
+    const { getAttachmentsServer } = await import("./attachment_model");
+
+    mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const result = await getAttachmentsServer("board-1");
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("addLinkAttachmentServer", () => {
+  it("inserts a link attachment and returns updated list", async () => {
+    const { addLinkAttachmentServer } = await import("./attachment_model");
+
+    // INSERT
+    mockPoolQuery.mockResolvedValueOnce({ rowCount: 1 });
+    // getAttachmentsServer
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ id: "att-1", board_id: "board-1", filename: "doc.pdf", link: "https://example.com/doc.pdf", type: "link", image_data: null, created_at: "2026-01-01T00:00:00Z" }],
+      rowCount: 1,
+    });
+
+    const result = await addLinkAttachmentServer("board-1", "doc.pdf", "https://example.com/doc.pdf");
+
+    expect(mockPoolQuery.mock.calls[0][0]).toContain("INSERT INTO attachments");
+    expect(mockPoolQuery.mock.calls[0][1]).toContain("board-1");
+    expect(mockPoolQuery.mock.calls[0][1]).toContain("doc.pdf");
+    expect(mockPoolQuery.mock.calls[0][1]).toContain("https://example.com/doc.pdf");
+    expect(mockPoolQuery.mock.calls[0][1]).toContain("link");
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe("addImageAttachmentServer", () => {
+  it("inserts an image attachment and returns updated list", async () => {
+    const { addImageAttachmentServer } = await import("./attachment_model");
+
+    const imageData = "data:image/jpeg;base64,/9j/4AAQ...";
+
+    // COUNT check (under limit)
+    mockPoolQuery.mockResolvedValueOnce({ rows: [{ count: "0" }], rowCount: 1 });
+    // INSERT
+    mockPoolQuery.mockResolvedValueOnce({ rowCount: 1 });
+    // getAttachmentsServer
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ id: "att-1", board_id: "board-1", filename: "photo.jpg", link: null, type: "image", image_data: imageData, created_at: "2026-01-01T00:00:00Z" }],
+      rowCount: 1,
+    });
+
+    const result = await addImageAttachmentServer("board-1", "photo.jpg", imageData);
+
+    expect(mockPoolQuery.mock.calls[0][0]).toContain("COUNT");
+    expect(mockPoolQuery.mock.calls[1][0]).toContain("INSERT INTO attachments");
+    expect(mockPoolQuery.mock.calls[1][1]).toContain("image");
+    expect(mockPoolQuery.mock.calls[1][1]).toContain(imageData);
+    expect(result).toHaveLength(1);
+  });
+
+  it("rejects images that exceed the size limit", async () => {
+    const { addImageAttachmentServer } = await import("./attachment_model");
+
+    // Create a string > 250KB
+    const oversizedData = "data:image/jpeg;base64," + "A".repeat(300_000);
+
+    await expect(addImageAttachmentServer("board-1", "huge.jpg", oversizedData)).rejects.toThrow(
+      "Image data exceeds maximum size of 250KB"
+    );
+
+    // Should not have called DB
+    expect(mockPoolQuery).not.toHaveBeenCalled();
+  });
+
+  it("enforces the 5-image upload limit", async () => {
+    const { addImageAttachmentServer } = await import("./attachment_model");
+
+    // Count query returns 5 existing images
+    mockPoolQuery.mockResolvedValueOnce({ rows: [{ count: "5" }], rowCount: 1 });
+
+    await expect(addImageAttachmentServer("board-1", "photo.jpg", "data:image/jpeg;base64,abc")).rejects.toThrow(
+      "Maximum of 5 uploaded images per board"
+    );
+  });
+});
+
+describe("deleteAttachmentServer", () => {
+  it("deletes an attachment and returns updated list", async () => {
+    const { deleteAttachmentServer } = await import("./attachment_model");
+
+    // DELETE
+    mockPoolQuery.mockResolvedValueOnce({ rowCount: 1 });
+    // getAttachmentsServer
+    mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const result = await deleteAttachmentServer("board-1", "att-1");
+
+    expect(mockPoolQuery.mock.calls[0][0]).toContain("DELETE FROM attachments");
+    expect(mockPoolQuery.mock.calls[0][1]).toEqual(["att-1", "board-1"]);
+    expect(result).toEqual([]);
+  });
+});

--- a/app/server/attachment_model.ts
+++ b/app/server/attachment_model.ts
@@ -1,0 +1,79 @@
+// ---------------------------------------------------------------------------
+// attachment_model.ts — DB access for board attachments
+// ---------------------------------------------------------------------------
+
+import { pool } from "./db_config";
+import type { AttachmentDTO } from "./board.types";
+
+const MAX_IMAGE_SIZE = 250_000; // 250KB
+const MAX_IMAGE_UPLOADS = 5;
+
+// ---------------------------------------------------------------------------
+// READ
+// ---------------------------------------------------------------------------
+
+export async function getAttachmentsServer(boardId: string): Promise<AttachmentDTO[]> {
+  const res = await pool.query(
+    `SELECT id, board_id, filename, link, type, image_data, created_at
+     FROM attachments
+     WHERE board_id = $1
+     ORDER BY created_at ASC`,
+    [boardId]
+  );
+  return res.rows as AttachmentDTO[];
+}
+
+// ---------------------------------------------------------------------------
+// WRITE
+// ---------------------------------------------------------------------------
+
+export async function addLinkAttachmentServer(
+  boardId: string,
+  filename: string,
+  link: string
+): Promise<AttachmentDTO[]> {
+  await pool.query(
+    `INSERT INTO attachments (id, board_id, filename, link, type)
+     VALUES (gen_random_uuid(), $1, $2, $3, $4)`,
+    [boardId, filename, link, "link"]
+  );
+  return getAttachmentsServer(boardId);
+}
+
+export async function addImageAttachmentServer(
+  boardId: string,
+  filename: string,
+  imageData: string
+): Promise<AttachmentDTO[]> {
+  // Validate size
+  if (imageData.length > MAX_IMAGE_SIZE) {
+    throw new Error("Image data exceeds maximum size of 250KB");
+  }
+
+  // Check image count limit
+  const countRes = await pool.query(
+    `SELECT COUNT(*) as count FROM attachments WHERE board_id = $1 AND type = 'image'`,
+    [boardId]
+  );
+  if (parseInt(countRes.rows[0].count, 10) >= MAX_IMAGE_UPLOADS) {
+    throw new Error("Maximum of 5 uploaded images per board");
+  }
+
+  await pool.query(
+    `INSERT INTO attachments (id, board_id, filename, link, type, image_data)
+     VALUES (gen_random_uuid(), $1, $2, NULL, $3, $4)`,
+    [boardId, filename, "image", imageData]
+  );
+  return getAttachmentsServer(boardId);
+}
+
+export async function deleteAttachmentServer(
+  boardId: string,
+  attachmentId: string
+): Promise<AttachmentDTO[]> {
+  await pool.query(
+    `DELETE FROM attachments WHERE id = $1 AND board_id = $2`,
+    [attachmentId, boardId]
+  );
+  return getAttachmentsServer(boardId);
+}

--- a/app/server/board.types.ts
+++ b/app/server/board.types.ts
@@ -27,6 +27,16 @@ export interface ColumnDTO {
   notes: NoteDTO[];
 }
 
+export interface AttachmentDTO {
+  id: string;
+  board_id: string;
+  filename: string;
+  link: string | null;
+  type: "link" | "image";
+  image_data: string | null;
+  created_at: string;
+}
+
 export interface BoardDTO {
   id: string;
   title: string;
@@ -38,6 +48,7 @@ export interface BoardDTO {
   votingEnabled?: boolean;
   votingAllowed?: number;
   columns: ColumnDTO[];
+  attachments?: AttachmentDTO[];
 }
 
 // ---------------------------------------------------------------------------
@@ -46,6 +57,7 @@ export interface BoardDTO {
 // ---------------------------------------------------------------------------
 
 export interface Note extends NoteDTO { }   // identical for now, alias for clarity
+export interface Attachment extends AttachmentDTO { }
 
 export interface Column extends ColumnDTO {
   notes: Note[];
@@ -63,6 +75,8 @@ export interface BoardClientState {
   timerRunning: boolean;
   timerEndsAt: string | null;
   timeLeft: number | null;          // seconds remaining, ticked by interval
+  // Attachments
+  attachments: Attachment[];
   // Network status
   offline: boolean;
   // Voting
@@ -92,6 +106,9 @@ export interface BoardActions {
   moveNoteLocally: (fromColumnId: string, toColumnId: string, noteId: string, newIndex: number) => void;
   startTimer: (seconds: number) => void;
   stopTimer: () => void;
+  addLinkAttachment: (filename: string, link: string) => void;
+  addImageAttachment: (filename: string, imageData: string) => void;
+  deleteAttachment: (attachmentId: string) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/app/server/db_init.ts
+++ b/app/server/db_init.ts
@@ -166,6 +166,20 @@ export async function initializeDatabase() {
       CREATE INDEX IF NOT EXISTS idx_note_votes_user_id ON note_votes(user_id);
     `);
 
+    // 10 Create attachments table for board file links and uploaded images
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS attachments (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        board_id TEXT NOT NULL REFERENCES boards(id) ON DELETE CASCADE,
+        filename TEXT NOT NULL,
+        link TEXT,
+        type TEXT NOT NULL DEFAULT 'link',
+        image_data TEXT,
+        created_at TIMESTAMP NOT NULL DEFAULT NOW()
+      );
+      CREATE INDEX IF NOT EXISTS idx_attachments_board_id ON attachments(board_id);
+    `);
+
     console.log("Done");
     console.log("Inserting dev data...");
 


### PR DESCRIPTION
## Summary
- Board owners can attach external links (with filename + URL) and upload images directly to boards
- Link attachments display with colored file-type icons (PDF=red, DOCX=blue, XLSX=green, MD=purple, generic=gray) and open in new tabs
- Image uploads are compressed client-side to fit 250KB, shown as thumbnails in the list, and open in a preview modal when clicked
- Owner-only management: "Attach" button with paperclip icon in toolbar, hover-to-reveal delete X with confirmation dialog
- Limits: 5 uploaded images per board, unlimited links
- Full multi-user sync via polling

## Test plan
- [x] 7 new tests for attachment model (CRUD, size limit, image count limit) — all passing
- [x] TypeScript typecheck clean
- [x] Verify attaching a link persists and displays with correct file icon
- [x] Verify uploading a large image compresses and saves successfully
- [x] Verify 6th image upload is rejected with error message
- [x] Verify clicking image thumbnail opens preview modal (not new tab)
- [x] Verify delete confirmation dialog works and removes attachment
- [x] Verify non-owners cannot see Attach button or delete buttons
- [x] Verify attachments sync across multiple browser tabs