### PR TITLE
Add admin metrics dashboard with two-tier access control

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,56 @@ This file describes the codebase structure, development workflows, and conventio
 
 ---
 
+## Engineering Rules
+
+These rules apply to all work in this repository.
+
+### 1. Test-Driven Development
+
+Write tests before writing implementation code. Every feature must have tests that verify it works. Tests protect against regressions during refactoring.
+
+- Add a `*.test.ts` / `*.test.tsx` file alongside every new module, route, or component.
+- Tests must pass before a change is considered complete.
+- When fixing a bug, write a failing test that reproduces it first.
+
+### 2. Function Size
+
+Keep functions under **150 lines**. If a function grows beyond that, break it into smaller, well-named pieces. Smaller functions are easier to read, test, and debug.
+
+### 3. Language Preference
+
+**TypeScript is the default.** Python is acceptable as an alternative. Any other language requires strong justification — only warranted for performance-critical work or hard architectural constraints.
+
+### 4. Modular Plugin Architecture
+
+Organize code by **feature/domain**, not by type. Each domain owns all of its related logic together:
+
+```
+app/server/      # e.g. board_model.ts owns all board SQL
+app/routes/app/  # e.g. board.notes.ts owns note mutations
+app/context/     # e.g. BoardContext.tsx owns board client state
+```
+
+Wire domains together with minimal integration points at the top level. Avoid cross-domain imports except through well-defined interfaces.
+
+### 5. Centralized Configuration
+
+All environment variables must be **defined, validated, and loaded in one place at startup** (`app/server/db_config.ts`, `app/config/siteConfig.ts`). If a required variable is missing, the app must fail loudly at startup with a clear error — not silently at runtime.
+
+Never scatter `process.env` references throughout the codebase. Import config values from the config modules.
+
+### 6. Decision Logs
+
+Maintain a record of key decisions, current project state, and progress in `plan/`. Before starting a significant feature or refactor, note the approach and rationale. This allows new sessions to resume context without re-explaining the problem.
+
+When completing a meaningful change, update or create a brief note in `plan/` describing what was done and why.
+
+### 7. Keep Secrets Secret
+
+Never hardcode secrets, credentials, or API keys in source-controlled files. Always use environment variables. See the [Environment Variables](#environment-variables) section for the full list. Never commit `.env` files.
+
+---
+
 ## Project Overview
 
 **Retrograde** is a full-stack TypeScript/React SSR web app for facilitating retrospective meetings. Teams use it to create collaborative kanban-style boards with sticky notes, voting, timers, drag-and-drop, and OAuth authentication.
@@ -187,6 +237,11 @@ Test files mirror source files: `foo.ts` → `foo.test.ts` in the same directory
 npm test            # Run all tests
 ```
 
+**Workflow — write tests first:**
+1. Write a failing test that describes the expected behaviour.
+2. Implement the feature until the test passes.
+3. Refactor if needed; tests must remain green.
+
 **Patterns in use:**
 - `describe / it / expect` structure
 - `vi.mock()` for session, database, and environment variable dependencies
@@ -250,6 +305,10 @@ docker run -p 3000:3000 --env-file .env retrograde
 - Do not use a global state dispatcher bus — use separate fetchers per concern.
 - Do not import from `react-router-dom` — import from `react-router` (v7).
 - Do not use CSS modules or styled-components — use Tailwind utility classes.
-- Do not commit `.env` files.
+- Do not commit `.env` files or hardcode any secret in source code.
 - Do not collapse the 4-layer type system in `board.types.ts`.
 - Do not add migration files — schema changes go in `db_init.ts` as idempotent DDL.
+- Do not scatter `process.env` references — read config from `app/server/db_config.ts` or `app/config/siteConfig.ts`.
+- Do not write functions longer than 150 lines — break them up.
+- Do not ship a feature without a corresponding test.
+- Do not introduce a new language without strong justification — default to TypeScript.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,255 @@
+# CLAUDE.md — Retrograde
+
+This file describes the codebase structure, development workflows, and conventions for AI assistants working in this repository.
+
+---
+
+## Project Overview
+
+**Retrograde** is a full-stack TypeScript/React SSR web app for facilitating retrospective meetings. Teams use it to create collaborative kanban-style boards with sticky notes, voting, timers, drag-and-drop, and OAuth authentication.
+
+**Stack:** React 19, React Router 7, Tailwind CSS 4, PostgreSQL, Vite, Vitest  
+**Architecture:** Server-side rendered (SSR) with real-time polling for board updates (no WebSockets)
+
+---
+
+## Repository Structure
+
+```
+app/
+├── routes/
+│   ├── app/          # Authenticated routes (dashboard, board operations)
+│   ├── auth/         # OAuth login/logout/callback flows
+│   └── site/         # Public pages (home, about, contact, terms, privacy)
+├── components/       # React UI components (36+ .tsx files)
+├── context/          # React context providers (BoardContext, userContext)
+├── hooks/            # Custom React hooks (useAuth, useTheme)
+├── server/           # Backend server code & PostgreSQL models
+├── utils/            # Helper functions (exportBoard CSV/Markdown)
+├── config/           # App config (siteConfig, db_config)
+├── images/           # SVG icon components
+├── example-data/     # Sample boards for onboarding/tutorials
+├── root.tsx          # Root layout & error boundary
+├── routes.ts         # Route configuration
+├── session.server.ts # Session cookie management
+└── features.ts       # Feature flags
+public/               # Static assets (icons, PDFs)
+plan/                 # Feature planning documents
+```
+
+---
+
+## Development Commands
+
+```bash
+npm run dev         # Start dev server with HMR (React Router dev mode)
+npm run build       # Production build → /build directory
+npm start           # Serve production build
+npm test            # Run all tests once (Vitest)
+npm run typecheck   # Generate React Router types + TypeScript check
+```
+
+Always run `npm run typecheck` after making changes to catch type errors before committing.
+
+---
+
+## Environment Variables
+
+Copy these into a `.env` file (never commit `.env`):
+
+```bash
+# OAuth (required)
+OAUTH_CLIENT_ID=
+OAUTH_CLIENT_SECRET=
+OAUTH_AUTHORIZATION_URL=
+OAUTH_TOKEN_URL=
+OAUTH_USERINFO_URL=
+OAUTH_REDIRECT_URI=http://localhost:3000/auth/callback
+OAUTH_SCOPES=openid profile email
+
+# Session (required)
+SESSION_SECRET=
+
+# Database — use DATABASE_URL OR the individual PG_* vars
+DATABASE_URL=
+PG_HOST=
+PG_USER=
+PG_PASSWORD=
+PG_SCHEMA=
+```
+
+`NODE_ENV=production` auto-enables SSL on the database connection.
+
+---
+
+## Database
+
+- **PostgreSQL** via raw `pg` client — no ORM.
+- Tables: `boards`, `columns`, `notes`, `users`, `board_members`, `note_votes`, `note_likes`, `board_attachments`.
+- **Schema management:** `app/server/db_init.ts` runs idempotent `CREATE TABLE IF NOT EXISTS` on startup — no migration tool.
+- Queries use positional binding (`$1`, `$2`, …) and `json_build_object` for nested JSON responses.
+- Permission checks live in SQL via `EXISTS` sub-clauses (not application-layer guards).
+
+When adding a new table or column, add it to `db_init.ts` using `IF NOT EXISTS` / `ADD COLUMN IF NOT EXISTS` so it is safe to run repeatedly.
+
+---
+
+## Architecture Patterns
+
+### Route / Action Structure
+
+React Router 7 resource routes handle all mutations. Route files export:
+- `loader` — fetches data for GET requests
+- `action` — handles POST/PUT/DELETE mutations
+
+**Resource routes** (no UI, pure mutation handlers) live under `app/routes/app/` and are named by domain:
+```
+board.notes.ts       # CRUD for notes
+board.columns.ts     # CRUD for columns
+board.settings.ts    # Board settings mutations
+board.timer.ts       # Timer control
+board.attachments.ts # Attachment upload/delete
+```
+
+### State Management (BoardContext)
+
+`app/context/BoardContext.tsx` is the central state hub for active boards.
+
+Key pattern: **separate fetchers per concern** — do not use a single dispatcher bus.
+
+```ts
+const columnFetcher  = useFetcher();
+const noteFetcher    = useFetcher();
+const timerFetcher   = useFetcher();
+const settingsFetcher = useFetcher();
+```
+
+State is derived from server data; client-side overrides (e.g., drag-and-drop reordering) are ephemeral and do not block the server round-trip.
+
+### Layered Type System (`app/server/board.types.ts`)
+
+Types follow a strict 4-layer pattern — do not collapse these layers:
+
+| Layer | Name | Description |
+|-------|------|-------------|
+| 1 | **Server DTOs** | Exact shape of a DB row |
+| 2 | **Client State** | DTO + ephemeral client fields |
+| 3 | **Actions** | Mutation function signatures |
+| 4 | **Composed Type** | Full assembled board object |
+
+### Drag & Drop
+
+Uses `@dnd-kit` (not React DnD). Drag is disabled when notes or the board are locked. Separate sensor configs exist for mouse, touch, and keyboard.
+
+---
+
+## Code Conventions
+
+### File & Directory Naming
+
+| Type | Convention | Example |
+|------|-----------|---------|
+| React components | PascalCase | `BoardToolbar.tsx`, `CommandDeck.tsx` |
+| Server/model files | snake_case | `board_model.ts`, `db_config.ts` |
+| Type files | snake_case + `.types.ts` | `board.types.ts` |
+| Route resource files | kebab-case with dots | `board.notes.ts`, `board.settings.ts` |
+| Hooks | camelCase with `use` prefix | `useAuth.ts`, `useTheme.ts` |
+
+### Styling
+
+- **Tailwind CSS v4** — utility classes only; no CSS modules, no CSS-in-JS.
+- Use the `cn()` helper (`clsx` + `tailwind-merge`) for conditional classes.
+- Dark mode via `.dark` class on `<html>`.
+- Color scheme: blue (primary), green (secondary), amber (warnings), red (danger).
+
+### Component Props
+
+Pass `isOwner`, `isReadOnly`, and `readonly` flags through props/context rather than re-fetching permissions in child components.
+
+### File Headers
+
+Add a short comment block at the top of new files explaining purpose:
+
+```ts
+// app/server/my_model.ts
+// Database operations for [domain]. All queries use parameterized SQL.
+```
+
+---
+
+## Testing
+
+**Framework:** Vitest 4 + React Testing Library (jsdom environment)
+
+Test files mirror source files: `foo.ts` → `foo.test.ts` in the same directory.
+
+```bash
+npm test            # Run all tests
+```
+
+**Patterns in use:**
+- `describe / it / expect` structure
+- `vi.mock()` for session, database, and environment variable dependencies
+- Auth flows tested with mocked `process.env` OAuth vars
+- Component tests use `@testing-library/react` `render` + `screen` queries
+
+When adding a new route or model, add a corresponding `*.test.ts` file. Mock the database (`pg`) and session (`session.server`) — do not test against a real database.
+
+---
+
+## TypeScript
+
+- Strict mode enabled (`"strict": true`).
+- Target: ES2022.
+- Path alias: `~/*` → `./app/*` (use `~/` for all intra-app imports).
+- JSX transform: `"react-jsx"` (no need to import React in component files).
+- Run `npm run typecheck` (which calls `react-router typegen && tsc`) to regenerate route types and validate.
+
+---
+
+## Docker
+
+Multi-stage build:
+1. `development-dependencies` — installs all deps
+2. `production-dependencies` — installs prod-only deps
+3. `build` — runs `npm run build`
+4. `runtime` — minimal image serving the build
+
+Build and run locally:
+```bash
+docker build -t retrograde .
+docker run -p 3000:3000 --env-file .env retrograde
+```
+
+---
+
+## Key Files Quick Reference
+
+| File | Purpose |
+|------|---------|
+| `app/root.tsx` | Root layout, error boundary, global providers |
+| `app/routes.ts` | All route definitions |
+| `app/session.server.ts` | Session cookie setup |
+| `app/features.ts` | Feature flags |
+| `app/context/BoardContext.tsx` | Board state management (central hub) |
+| `app/server/board_model.ts` | All board-related SQL queries |
+| `app/server/db_init.ts` | Schema initialization (run on startup) |
+| `app/server/db_config.ts` | Database connection pool |
+| `app/server/board.types.ts` | Shared type definitions (4-layer system) |
+| `app/config/siteConfig.ts` | OAuth field mapping, logo, branding |
+| `app/components/CommandDeck.tsx` | Facilitator control panel UI |
+| `vite.config.ts` | Vite + React Router + Tailwind plugin config |
+| `react-router.config.ts` | SSR enabled |
+| `vitest.config.ts` | Test runner configuration |
+
+---
+
+## What Not To Do
+
+- Do not use an ORM — keep queries as raw parameterized SQL.
+- Do not use a global state dispatcher bus — use separate fetchers per concern.
+- Do not import from `react-router-dom` — import from `react-router` (v7).
+- Do not use CSS modules or styled-components — use Tailwind utility classes.
+- Do not commit `.env` files.
+- Do not collapse the 4-layer type system in `board.types.ts`.
+- Do not add migration files — schema changes go in `db_init.ts` as idempotent DDL.

--- a/app/config/siteConfig.ts
+++ b/app/config/siteConfig.ts
@@ -4,6 +4,9 @@
 export type SiteConfig = {
   dashboardHome: boolean;
   usernameField: string;
+  // List of external_id values (from the OAuth provider) that may access the
+  // admin metrics dashboard at /app/admin/dashboard. Empty = no one can access.
+  adminUsers: string[];
   logoLight?: string;
   logoDark?: string;
   logoAlt?: string;
@@ -18,8 +21,12 @@ export const siteConfig: SiteConfig = {
   // If you are using SSO, set the username field to whatever field in the OIDC token you want to use as the username.
   usernameField: "preferred_username",
 
-  // if you are going to provide logos, you must provide both light and dark 
-  // versions for proper theming support. Import them at the top of this file 
+  // Add the external_id values (as provided by your OAuth/SSO provider) for any
+  // users who should be able to view the admin metrics dashboard.
+  adminUsers: [],
+
+  // if you are going to provide logos, you must provide both light and dark
+  // versions for proper theming support. Import them at the top of this file
   // then add them to the config object below and provied alt text for accessibility.
   // logoLight,
   // logoDark,

--- a/app/config/siteConfig.ts
+++ b/app/config/siteConfig.ts
@@ -4,9 +4,6 @@
 export type SiteConfig = {
   dashboardHome: boolean;
   usernameField: string;
-  // List of external_id values (from the OAuth provider) that may access the
-  // admin metrics dashboard at /app/admin/dashboard. Empty = no one can access.
-  adminUsers: string[];
   logoLight?: string;
   logoDark?: string;
   logoAlt?: string;
@@ -20,10 +17,6 @@ export const siteConfig: SiteConfig = {
 
   // If you are using SSO, set the username field to whatever field in the OIDC token you want to use as the username.
   usernameField: "preferred_username",
-
-  // Add the external_id values (as provided by your OAuth/SSO provider) for any
-  // users who should be able to view the admin metrics dashboard.
-  adminUsers: [],
 
   // if you are going to provide logos, you must provide both light and dark
   // versions for proper theming support. Import them at the top of this file

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -17,6 +17,7 @@ export default [
   route("/app", "components/AppLayout.tsx", [
     route("dashboard", "routes/app/dashboard.tsx"),
     route("board/claim", "routes/app/board.claim.ts"),
+    route("admin/dashboard", "routes/app/admin.dashboard.tsx"),
   ]),
 
   /* Board Routes — authentication optional (anonymous access) */

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -18,6 +18,7 @@ export default [
     route("dashboard", "routes/app/dashboard.tsx"),
     route("board/claim", "routes/app/board.claim.ts"),
     route("admin/dashboard", "routes/app/admin.dashboard.tsx"),
+    route("admin/admins",   "routes/app/admin.admins.ts"),
   ]),
 
   /* Board Routes — authentication optional (anonymous access) */

--- a/app/routes/app/admin.admins.test.ts
+++ b/app/routes/app/admin.admins.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+let sessionData: Record<string, string> = {};
+
+vi.mock("~/session.server", () => ({
+  getSession: vi.fn(async () => ({
+    get: (key: string) => sessionData[key],
+    set: (key: string, value: string) => { sessionData[key] = value; },
+    unset: (key: string) => { delete sessionData[key]; },
+  })),
+  commitSession: vi.fn(async () => "session-cookie-value"),
+}));
+
+const mockPoolQuery = vi.fn();
+const SITE_ADMIN_EXT_ID = "site-admin-ext-123";
+
+vi.mock("~/server/db_config", () => ({
+  pool: { query: (...args: unknown[]) => mockPoolQuery(...args) },
+  siteAdminIds: [SITE_ADMIN_EXT_ID],
+}));
+
+vi.mock("~/server/db_init", () => ({}));
+
+const mockAdd    = vi.fn();
+const mockRemove = vi.fn();
+const mockFind   = vi.fn();
+
+vi.mock("~/server/admin_model", () => ({
+  addGrantedAdmin:               (...args: unknown[]) => mockAdd(...args),
+  removeGrantedAdmin:            (...args: unknown[]) => mockRemove(...args),
+  findRegisteredUserByUsername:  (...args: unknown[]) => mockFind(...args),
+}));
+
+vi.mock("~/config/siteConfig", () => ({
+  siteConfig: { usernameField: "preferred_username" },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessionData = {};
+  mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+});
+
+function loginAs(userId: string, externalId: string) {
+  sessionData["userId"] = userId;
+  // requireRegisteredUser → SELECT * FROM users WHERE id = $1
+  mockPoolQuery.mockResolvedValueOnce({
+    rows: [{ id: userId, preferred_username: "testuser", is_anonymous: false }],
+    rowCount: 1,
+  });
+  // requireSiteAdmin → SELECT external_id FROM users WHERE id = $1
+  mockPoolQuery.mockResolvedValueOnce({
+    rows: [{ external_id: externalId }],
+    rowCount: 1,
+  });
+}
+
+function makeRequest(intent: string, fields: Record<string, string> = {}) {
+  const form = new FormData();
+  form.append("intent", intent);
+  for (const [k, v] of Object.entries(fields)) form.append(k, v);
+  return new Request("http://localhost:3000/app/admin/admins", { method: "post", body: form });
+}
+
+describe("admin.admins action — access control", () => {
+  it("throws 403 for a non-site-admin registered user", async () => {
+    const { action } = await import("./admin.admins");
+    loginAs("user-1", "not-a-site-admin");
+
+    try {
+      await action({ request: makeRequest("add", { username: "someone" }) });
+      expect.unreachable("should have thrown 403");
+    } catch (res: unknown) {
+      expect((res as Response).status).toBe(403);
+    }
+  });
+
+  it("redirects to login when no session exists", async () => {
+    const { action } = await import("./admin.admins");
+
+    try {
+      await action({ request: makeRequest("add", { username: "someone" }) });
+      expect.unreachable("should have thrown a redirect");
+    } catch (res: unknown) {
+      expect((res as Response).status).toBe(302);
+    }
+  });
+});
+
+describe("admin.admins action — add intent", () => {
+  it("adds a user and returns success", async () => {
+    const { action } = await import("./admin.admins");
+    loginAs("admin-1", SITE_ADMIN_EXT_ID);
+    mockFind.mockResolvedValueOnce({ id: "target-1", username: "alice" });
+
+    const result = await action({ request: makeRequest("add", { username: "alice" }) });
+
+    expect(mockFind).toHaveBeenCalledWith("alice");
+    expect(mockAdd).toHaveBeenCalledWith("target-1", SITE_ADMIN_EXT_ID);
+    expect(result).toEqual({ success: true, addedUsername: "alice" });
+  });
+
+  it("returns error when username is empty", async () => {
+    const { action } = await import("./admin.admins");
+    loginAs("admin-1", SITE_ADMIN_EXT_ID);
+
+    const result = await action({ request: makeRequest("add", { username: "  " }) });
+
+    expect(mockFind).not.toHaveBeenCalled();
+    expect(result).toEqual({ error: "Username is required." });
+  });
+
+  it("returns error when user is not found", async () => {
+    const { action } = await import("./admin.admins");
+    loginAs("admin-1", SITE_ADMIN_EXT_ID);
+    mockFind.mockResolvedValueOnce(null);
+
+    const result = await action({ request: makeRequest("add", { username: "ghost" }) });
+
+    expect(mockAdd).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ error: expect.stringContaining("ghost") });
+  });
+});
+
+describe("admin.admins action — remove intent", () => {
+  it("removes a user and returns success", async () => {
+    const { action } = await import("./admin.admins");
+    loginAs("admin-1", SITE_ADMIN_EXT_ID);
+
+    const result = await action({ request: makeRequest("remove", { userId: "target-1" }) });
+
+    expect(mockRemove).toHaveBeenCalledWith("target-1");
+    expect(result).toEqual({ success: true });
+  });
+
+  it("returns error when userId is missing", async () => {
+    const { action } = await import("./admin.admins");
+    loginAs("admin-1", SITE_ADMIN_EXT_ID);
+
+    const result = await action({ request: makeRequest("remove") });
+
+    expect(mockRemove).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ error: "Missing userId." });
+  });
+});
+
+describe("admin.admins action — unknown intent", () => {
+  it("throws 400 for an unrecognised intent", async () => {
+    const { action } = await import("./admin.admins");
+    loginAs("admin-1", SITE_ADMIN_EXT_ID);
+
+    try {
+      await action({ request: makeRequest("nuke") });
+      expect.unreachable("should have thrown 400");
+    } catch (res: unknown) {
+      expect((res as Response).status).toBe(400);
+    }
+  });
+});

--- a/app/routes/app/admin.admins.ts
+++ b/app/routes/app/admin.admins.ts
@@ -1,0 +1,59 @@
+// app/routes/app/admin.admins.ts
+// Resource route for managing granted admin users.
+// Only site admins (those listed in SITE_ADMIN_IDS) may call these actions.
+
+import { requireRegisteredUser } from "~/hooks/useAuth";
+import { pool, siteAdminIds } from "~/server/db_config";
+import {
+  addGrantedAdmin,
+  findRegisteredUserByUsername,
+  removeGrantedAdmin,
+} from "~/server/admin_model";
+
+async function requireSiteAdmin(request: Request) {
+  const user = await requireRegisteredUser(request);
+
+  const userRow = await pool.query(
+    "SELECT external_id FROM users WHERE id = $1",
+    [user.id]
+  );
+  const externalId: string | undefined = userRow.rows[0]?.external_id;
+
+  if (!externalId || !siteAdminIds.includes(externalId)) {
+    throw new Response("Forbidden", { status: 403 });
+  }
+
+  return { ...user, externalId };
+}
+
+export async function action({ request }: { request: Request }) {
+  const admin = await requireSiteAdmin(request);
+  const formData = await request.formData();
+  const intent = formData.get("intent")?.toString();
+
+  if (intent === "add") {
+    const username = formData.get("username")?.toString().trim();
+    if (!username) {
+      return { error: "Username is required." };
+    }
+
+    const target = await findRegisteredUserByUsername(username);
+    if (!target) {
+      return { error: `No registered user found with username "${username}".` };
+    }
+
+    await addGrantedAdmin(target.id, admin.externalId);
+    return { success: true, addedUsername: target.username };
+  }
+
+  if (intent === "remove") {
+    const userId = formData.get("userId")?.toString();
+    if (!userId) {
+      return { error: "Missing userId." };
+    }
+    await removeGrantedAdmin(userId);
+    return { success: true };
+  }
+
+  throw new Response("Bad Request", { status: 400 });
+}

--- a/app/routes/app/admin.dashboard.test.ts
+++ b/app/routes/app/admin.dashboard.test.ts
@@ -12,154 +12,166 @@ vi.mock("~/session.server", () => ({
 }));
 
 const mockPoolQuery = vi.fn();
+const SITE_ADMIN_EXT_ID = "site-admin-ext-123";
+
 vi.mock("~/server/db_config", () => ({
   pool: { query: (...args: unknown[]) => mockPoolQuery(...args) },
+  siteAdminIds: [SITE_ADMIN_EXT_ID],
 }));
 
 vi.mock("~/server/db_init", () => ({}));
 
-const mockGetMetrics = vi.fn();
+const mockGetMetrics      = vi.fn();
+const mockIsGrantedAdmin  = vi.fn();
+const mockListGranted     = vi.fn();
+
 vi.mock("~/server/metrics_model", () => ({
   getMetrics: (...args: unknown[]) => mockGetMetrics(...args),
 }));
 
-const ADMIN_EXTERNAL_ID = "admin-ext-id-123";
+vi.mock("~/server/admin_model", () => ({
+  isGrantedAdmin:    (...args: unknown[]) => mockIsGrantedAdmin(...args),
+  listGrantedAdmins: (...args: unknown[]) => mockListGranted(...args),
+}));
 
 vi.mock("~/config/siteConfig", () => ({
-  siteConfig: {
-    usernameField: "preferred_username",
-    adminUsers: [ADMIN_EXTERNAL_ID],
-  },
+  siteConfig: { usernameField: "preferred_username" },
 }));
+
+const SAMPLE_METRICS = { registeredUsers: 10, totalNotes: 50, activeBoards: 3, engagedUsers: 7 };
+const SAMPLE_GRANTED = [{ id: "au-1", userId: "u-2", username: "alice", grantedBy: SITE_ADMIN_EXT_ID, createdAt: "2025-01-01T00:00:00Z" }];
 
 beforeEach(() => {
   vi.clearAllMocks();
   sessionData = {};
   mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+  mockGetMetrics.mockResolvedValue(SAMPLE_METRICS);
+  mockListGranted.mockResolvedValue(SAMPLE_GRANTED);
+  mockIsGrantedAdmin.mockResolvedValue(false);
 });
 
-// Sets up a logged-in session. The first pool.query call is the user lookup
-// from requireRegisteredUser; the second is the external_id lookup in the loader.
+// Sets up a logged-in session. Pool calls:
+//   1. requireRegisteredUser → SELECT * FROM users WHERE id
+//   2. loader → SELECT external_id FROM users WHERE id
 function loginAs(userId: string, externalId: string, isAnonymous = false) {
   sessionData["userId"] = userId;
-  // requireRegisteredUser → SELECT * FROM users WHERE id = $1
   mockPoolQuery.mockResolvedValueOnce({
     rows: [{ id: userId, preferred_username: "testuser", is_anonymous: isAnonymous }],
     rowCount: 1,
   });
-  // loader → SELECT external_id FROM users WHERE id = $1
   mockPoolQuery.mockResolvedValueOnce({
     rows: [{ external_id: externalId }],
     rowCount: 1,
   });
 }
 
-const SAMPLE_METRICS = {
-  registeredUsers: 50,
-  totalNotes: 200,
-  activeBoards: 10,
-  engagedUsers: 40,
-};
-
-describe("admin dashboard loader", () => {
-  it("returns metrics for a user in adminUsers", async () => {
+describe("admin dashboard loader — site admin", () => {
+  it("returns metrics, isSiteAdmin: true, and grantedAdmins", async () => {
     const { loader } = await import("./admin.dashboard");
+    loginAs("admin-1", SITE_ADMIN_EXT_ID);
 
-    loginAs("user-1", ADMIN_EXTERNAL_ID);
-    mockGetMetrics.mockResolvedValueOnce(SAMPLE_METRICS);
+    const result = await loader({ request: new Request("http://localhost:3000/app/admin/dashboard") });
 
-    const request = new Request("http://localhost:3000/app/admin/dashboard");
-    const result = await loader({ request });
-
-    expect(result).toEqual({ metrics: SAMPLE_METRICS });
-    expect(mockGetMetrics).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      metrics: SAMPLE_METRICS,
+      isSiteAdmin: true,
+      grantedAdmins: SAMPLE_GRANTED,
+    });
+    expect(mockIsGrantedAdmin).not.toHaveBeenCalled();
   });
 
-  it("throws 403 for a registered user not in adminUsers", async () => {
+  it("does not call isGrantedAdmin for site admins", async () => {
     const { loader } = await import("./admin.dashboard");
+    loginAs("admin-1", SITE_ADMIN_EXT_ID);
 
-    loginAs("user-2", "some-other-external-id");
+    await loader({ request: new Request("http://localhost:3000/app/admin/dashboard") });
 
-    const request = new Request("http://localhost:3000/app/admin/dashboard");
+    expect(mockIsGrantedAdmin).not.toHaveBeenCalled();
+  });
+});
+
+describe("admin dashboard loader — granted admin", () => {
+  it("returns metrics and isSiteAdmin: false with empty grantedAdmins", async () => {
+    const { loader } = await import("./admin.dashboard");
+    loginAs("user-2", "other-ext-id");
+    mockIsGrantedAdmin.mockResolvedValueOnce(true);
+
+    const result = await loader({ request: new Request("http://localhost:3000/app/admin/dashboard") });
+
+    expect(result).toEqual({
+      metrics: SAMPLE_METRICS,
+      isSiteAdmin: false,
+      grantedAdmins: [],
+    });
+    expect(mockListGranted).not.toHaveBeenCalled();
+  });
+});
+
+describe("admin dashboard loader — access denied", () => {
+  it("throws 403 when user is neither site admin nor granted admin", async () => {
+    const { loader } = await import("./admin.dashboard");
+    loginAs("user-3", "unrecognised-ext-id");
+    mockIsGrantedAdmin.mockResolvedValueOnce(false);
 
     try {
-      await loader({ request });
+      await loader({ request: new Request("http://localhost:3000/app/admin/dashboard") });
       expect.unreachable("should have thrown 403");
-    } catch (response: unknown) {
-      expect((response as Response).status).toBe(403);
+    } catch (res: unknown) {
+      expect((res as Response).status).toBe(403);
     }
   });
 
-  it("throws 403 when the user row has no external_id", async () => {
+  it("throws 403 when the users row has no external_id and is not a granted admin", async () => {
     const { loader } = await import("./admin.dashboard");
-
-    sessionData["userId"] = "user-3";
-    // requireRegisteredUser
+    sessionData["userId"] = "user-4";
     mockPoolQuery.mockResolvedValueOnce({
-      rows: [{ id: "user-3", preferred_username: "testuser", is_anonymous: false }],
+      rows: [{ id: "user-4", preferred_username: "testuser", is_anonymous: false }],
       rowCount: 1,
     });
-    // external_id lookup returns empty
-    mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
-
-    const request = new Request("http://localhost:3000/app/admin/dashboard");
+    mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // no external_id
+    mockIsGrantedAdmin.mockResolvedValueOnce(false);
 
     try {
-      await loader({ request });
+      await loader({ request: new Request("http://localhost:3000/app/admin/dashboard") });
       expect.unreachable("should have thrown 403");
-    } catch (response: unknown) {
-      expect((response as Response).status).toBe(403);
+    } catch (res: unknown) {
+      expect((res as Response).status).toBe(403);
     }
   });
 
-  it("redirects to login when no session exists", async () => {
+  it("redirects unauthenticated users to login", async () => {
     const { loader } = await import("./admin.dashboard");
 
-    const request = new Request("http://localhost:3000/app/admin/dashboard");
-
     try {
-      await loader({ request });
+      await loader({ request: new Request("http://localhost:3000/app/admin/dashboard") });
       expect.unreachable("should have thrown a redirect");
-    } catch (response: unknown) {
-      const res = response as Response;
-      expect(res.status).toBe(302);
-      expect(res.headers.get("Location")).toContain("/auth/login");
+    } catch (res: unknown) {
+      const r = res as Response;
+      expect(r.status).toBe(302);
+      expect(r.headers.get("Location")).toContain("/auth/login");
     }
   });
 
   it("redirects anonymous users to login", async () => {
     const { loader } = await import("./admin.dashboard");
-
-    sessionData["userId"] = "anon-1";
-    mockPoolQuery.mockResolvedValueOnce({
-      rows: [{ id: "anon-1", preferred_username: "Guest", is_anonymous: true }],
-      rowCount: 1,
-    });
-
-    const request = new Request("http://localhost:3000/app/admin/dashboard");
+    loginAs("anon-1", "ext-anon", true);
 
     try {
-      await loader({ request });
+      await loader({ request: new Request("http://localhost:3000/app/admin/dashboard") });
       expect.unreachable("should have thrown a redirect");
-    } catch (response: unknown) {
-      const res = response as Response;
-      expect(res.status).toBe(302);
-      expect(res.headers.get("Location")).toContain("/auth/login");
+    } catch (res: unknown) {
+      expect((res as Response).status).toBe(302);
     }
   });
 
   it("does not call getMetrics when access is denied", async () => {
     const { loader } = await import("./admin.dashboard");
-
-    loginAs("user-4", "not-an-admin");
-
-    const request = new Request("http://localhost:3000/app/admin/dashboard");
+    loginAs("user-5", "unrecognised");
+    mockIsGrantedAdmin.mockResolvedValueOnce(false);
 
     try {
-      await loader({ request });
-    } catch {
-      // expected 403
-    }
+      await loader({ request: new Request("http://localhost:3000/app/admin/dashboard") });
+    } catch { /* expected 403 */ }
 
     expect(mockGetMetrics).not.toHaveBeenCalled();
   });

--- a/app/routes/app/admin.dashboard.test.ts
+++ b/app/routes/app/admin.dashboard.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+let sessionData: Record<string, string> = {};
+
+vi.mock("~/session.server", () => ({
+  getSession: vi.fn(async () => ({
+    get: (key: string) => sessionData[key],
+    set: (key: string, value: string) => { sessionData[key] = value; },
+    unset: (key: string) => { delete sessionData[key]; },
+  })),
+  commitSession: vi.fn(async () => "session-cookie-value"),
+}));
+
+const mockPoolQuery = vi.fn();
+vi.mock("~/server/db_config", () => ({
+  pool: { query: (...args: unknown[]) => mockPoolQuery(...args) },
+}));
+
+vi.mock("~/server/db_init", () => ({}));
+
+const mockGetMetrics = vi.fn();
+vi.mock("~/server/metrics_model", () => ({
+  getMetrics: (...args: unknown[]) => mockGetMetrics(...args),
+}));
+
+const ADMIN_EXTERNAL_ID = "admin-ext-id-123";
+
+vi.mock("~/config/siteConfig", () => ({
+  siteConfig: {
+    usernameField: "preferred_username",
+    adminUsers: [ADMIN_EXTERNAL_ID],
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessionData = {};
+  mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+});
+
+// Sets up a logged-in session. The first pool.query call is the user lookup
+// from requireRegisteredUser; the second is the external_id lookup in the loader.
+function loginAs(userId: string, externalId: string, isAnonymous = false) {
+  sessionData["userId"] = userId;
+  // requireRegisteredUser → SELECT * FROM users WHERE id = $1
+  mockPoolQuery.mockResolvedValueOnce({
+    rows: [{ id: userId, preferred_username: "testuser", is_anonymous: isAnonymous }],
+    rowCount: 1,
+  });
+  // loader → SELECT external_id FROM users WHERE id = $1
+  mockPoolQuery.mockResolvedValueOnce({
+    rows: [{ external_id: externalId }],
+    rowCount: 1,
+  });
+}
+
+const SAMPLE_METRICS = {
+  registeredUsers: 50,
+  totalNotes: 200,
+  activeBoards: 10,
+  engagedUsers: 40,
+};
+
+describe("admin dashboard loader", () => {
+  it("returns metrics for a user in adminUsers", async () => {
+    const { loader } = await import("./admin.dashboard");
+
+    loginAs("user-1", ADMIN_EXTERNAL_ID);
+    mockGetMetrics.mockResolvedValueOnce(SAMPLE_METRICS);
+
+    const request = new Request("http://localhost:3000/app/admin/dashboard");
+    const result = await loader({ request });
+
+    expect(result).toEqual({ metrics: SAMPLE_METRICS });
+    expect(mockGetMetrics).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws 403 for a registered user not in adminUsers", async () => {
+    const { loader } = await import("./admin.dashboard");
+
+    loginAs("user-2", "some-other-external-id");
+
+    const request = new Request("http://localhost:3000/app/admin/dashboard");
+
+    try {
+      await loader({ request });
+      expect.unreachable("should have thrown 403");
+    } catch (response: unknown) {
+      expect((response as Response).status).toBe(403);
+    }
+  });
+
+  it("throws 403 when the user row has no external_id", async () => {
+    const { loader } = await import("./admin.dashboard");
+
+    sessionData["userId"] = "user-3";
+    // requireRegisteredUser
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ id: "user-3", preferred_username: "testuser", is_anonymous: false }],
+      rowCount: 1,
+    });
+    // external_id lookup returns empty
+    mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const request = new Request("http://localhost:3000/app/admin/dashboard");
+
+    try {
+      await loader({ request });
+      expect.unreachable("should have thrown 403");
+    } catch (response: unknown) {
+      expect((response as Response).status).toBe(403);
+    }
+  });
+
+  it("redirects to login when no session exists", async () => {
+    const { loader } = await import("./admin.dashboard");
+
+    const request = new Request("http://localhost:3000/app/admin/dashboard");
+
+    try {
+      await loader({ request });
+      expect.unreachable("should have thrown a redirect");
+    } catch (response: unknown) {
+      const res = response as Response;
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toContain("/auth/login");
+    }
+  });
+
+  it("redirects anonymous users to login", async () => {
+    const { loader } = await import("./admin.dashboard");
+
+    sessionData["userId"] = "anon-1";
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ id: "anon-1", preferred_username: "Guest", is_anonymous: true }],
+      rowCount: 1,
+    });
+
+    const request = new Request("http://localhost:3000/app/admin/dashboard");
+
+    try {
+      await loader({ request });
+      expect.unreachable("should have thrown a redirect");
+    } catch (response: unknown) {
+      const res = response as Response;
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toContain("/auth/login");
+    }
+  });
+
+  it("does not call getMetrics when access is denied", async () => {
+    const { loader } = await import("./admin.dashboard");
+
+    loginAs("user-4", "not-an-admin");
+
+    const request = new Request("http://localhost:3000/app/admin/dashboard");
+
+    try {
+      await loader({ request });
+    } catch {
+      // expected 403
+    }
+
+    expect(mockGetMetrics).not.toHaveBeenCalled();
+  });
+});

--- a/app/routes/app/admin.dashboard.tsx
+++ b/app/routes/app/admin.dashboard.tsx
@@ -1,14 +1,16 @@
 // app/routes/app/admin.dashboard.tsx
-// Admin metrics dashboard — access restricted to users listed in siteConfig.adminUsers.
-// Displays aggregate usage counts only; no per-user or per-board details.
+// Admin dashboard: aggregate usage metrics + granted-admin management.
+// Site admins (SITE_ADMIN_IDS env var) see everything and can manage other admins.
+// Granted admins (admin_users table) see metrics only.
 
 export const meta = () => [{ title: "Admin Dashboard – Retrograde" }];
 
-import { useLoaderData } from "react-router";
+import { useEffect, useRef } from "react";
+import { useLoaderData, useFetcher } from "react-router";
 import { requireRegisteredUser } from "~/hooks/useAuth";
-import { pool } from "~/server/db_config";
-import { siteConfig } from "~/config/siteConfig";
+import { pool, siteAdminIds } from "~/server/db_config";
 import { getMetrics, type MetricsDTO } from "~/server/metrics_model";
+import { isGrantedAdmin, listGrantedAdmins, type GrantedAdmin } from "~/server/admin_model";
 
 export async function loader({ request }: { request: Request }) {
   const user = await requireRegisteredUser(request);
@@ -18,22 +20,25 @@ export async function loader({ request }: { request: Request }) {
     [user.id]
   );
   const externalId: string | undefined = userRow.rows[0]?.external_id;
+  const isSiteAdmin = Boolean(externalId && siteAdminIds.includes(externalId));
 
-  if (!externalId || !siteConfig.adminUsers.includes(externalId)) {
+  if (!isSiteAdmin && !(await isGrantedAdmin(user.id))) {
     throw new Response("Forbidden", { status: 403 });
   }
 
-  const metrics = await getMetrics();
-  return { metrics };
+  const [metrics, grantedAdmins] = await Promise.all([
+    getMetrics(),
+    isSiteAdmin ? listGrantedAdmins() : Promise.resolve([]),
+  ]);
+
+  return { metrics, isSiteAdmin, grantedAdmins };
 }
 
-interface StatCardProps {
-  label: string;
-  value: number;
-  description: string;
-}
+// ---------------------------------------------------------------------------
+// Stat card
+// ---------------------------------------------------------------------------
 
-function StatCard({ label, value, description }: StatCardProps) {
+function StatCard({ label, value, description }: { label: string; value: number; description: string }) {
   return (
     <div className="border rounded-lg p-6 flex flex-col gap-2 bg-white dark:bg-gray-900">
       <div className="text-4xl font-bold text-blue-600 dark:text-blue-400">
@@ -45,8 +50,96 @@ function StatCard({ label, value, description }: StatCardProps) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Manage Admins (site admins only)
+// ---------------------------------------------------------------------------
+
+function ManageAdmins({ grantedAdmins }: { grantedAdmins: GrantedAdmin[] }) {
+  const addFetcher    = useFetcher<{ success?: boolean; addedUsername?: string; error?: string }>();
+  const removeFetcher = useFetcher<{ success?: boolean; error?: string }>();
+  const formRef       = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    if (addFetcher.data?.success) formRef.current?.reset();
+  }, [addFetcher.data]);
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-1">Manage Admins</h2>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+        Site admins are set via the <code className="font-mono bg-gray-100 dark:bg-gray-800 px-1 rounded">SITE_ADMIN_IDS</code> environment variable and are not listed here.
+      </p>
+
+      {grantedAdmins.length === 0 ? (
+        <p className="text-sm text-gray-400 dark:text-gray-600 mb-6">No granted admins yet.</p>
+      ) : (
+        <div className="overflow-x-auto border rounded-lg mb-6">
+          <table className="table-auto w-full">
+            <thead>
+              <tr>
+                <th className="text-left px-4 py-2 border-b-2">Username</th>
+                <th className="text-left px-4 py-2 border-b-2">Granted</th>
+                <th className="px-4 py-2 border-b-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {grantedAdmins.map((admin) => (
+                <tr key={admin.id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+                  <td className="px-4 py-3 border-b dark:border-gray-700">{admin.username}</td>
+                  <td className="px-4 py-3 border-b dark:border-gray-700 text-sm text-gray-500">
+                    {new Date(admin.createdAt).toLocaleDateString()}
+                  </td>
+                  <td className="px-4 py-3 border-b dark:border-gray-700 text-right">
+                    <removeFetcher.Form method="post" action="/app/admin/admins">
+                      <input type="hidden" name="intent"  value="remove" />
+                      <input type="hidden" name="userId"  value={admin.userId} />
+                      <button type="submit" className="text-sm text-red-500 hover:text-red-700 cursor-pointer">
+                        Remove
+                      </button>
+                    </removeFetcher.Form>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <h3 className="text-sm font-semibold mb-2">Grant access by username</h3>
+      <addFetcher.Form ref={formRef} method="post" action="/app/admin/admins" className="flex gap-2 items-start flex-wrap">
+        <input type="hidden" name="intent" value="add" />
+        <div className="flex flex-col gap-1">
+          <input
+            type="text"
+            name="username"
+            placeholder="Username"
+            required
+            className="border rounded px-3 py-1.5 border-blue-400 dark:border-blue-800 bg-blue-50 dark:bg-blue-950"
+          />
+          {addFetcher.data?.error   && <p className="text-sm text-red-500">{addFetcher.data.error}</p>}
+          {addFetcher.data?.success && <p className="text-sm text-green-600">Access granted to {addFetcher.data.addedUsername}.</p>}
+        </div>
+        <button
+          type="submit"
+          className="px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white rounded text-sm cursor-pointer"
+        >
+          Grant Access
+        </button>
+      </addFetcher.Form>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
 export default function AdminDashboard() {
-  const { metrics } = useLoaderData<typeof loader>() as { metrics: MetricsDTO };
+  const { metrics, isSiteAdmin, grantedAdmins } = useLoaderData<typeof loader>() as {
+    metrics: MetricsDTO;
+    isSiteAdmin: boolean;
+    grantedAdmins: GrantedAdmin[];
+  };
 
   return (
     <div className="px-8 mx-auto w-full sm:w-[80%]">
@@ -56,29 +149,19 @@ export default function AdminDashboard() {
       </p>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-10">
-        <StatCard
-          label="Registered Users"
-          value={metrics.registeredUsers}
-          description="Non-anonymous accounts created via OAuth."
-        />
-        <StatCard
-          label="Notes Created"
-          value={metrics.totalNotes}
-          description="Total sticky notes across all boards."
-        />
-        <StatCard
-          label="Active Boards"
-          value={metrics.activeBoards}
-          description="Boards with real usage: a second contributor added a note, or the owner created 5 or more notes."
-        />
-        <StatCard
-          label="Engaged Users"
-          value={metrics.engagedUsers}
-          description="Registered users who are members of at least one active board."
-        />
+        <StatCard label="Registered Users"  value={metrics.registeredUsers} description="Non-anonymous accounts created via OAuth." />
+        <StatCard label="Notes Created"     value={metrics.totalNotes}      description="Total sticky notes across all boards." />
+        <StatCard label="Active Boards"     value={metrics.activeBoards}    description="Boards with real usage: a second contributor added a note, or the owner created 5 or more notes." />
+        <StatCard label="Engaged Users"     value={metrics.engagedUsers}    description="Registered users who are members of at least one active board." />
       </div>
 
-      <p className="text-xs text-gray-400 dark:text-gray-600">
+      {isSiteAdmin && (
+        <div className="border-t pt-8 mt-4">
+          <ManageAdmins grantedAdmins={grantedAdmins} />
+        </div>
+      )}
+
+      <p className="text-xs text-gray-400 dark:text-gray-600 mt-8">
         Data reflects the current state of the database.
       </p>
     </div>

--- a/app/routes/app/admin.dashboard.tsx
+++ b/app/routes/app/admin.dashboard.tsx
@@ -1,0 +1,86 @@
+// app/routes/app/admin.dashboard.tsx
+// Admin metrics dashboard — access restricted to users listed in siteConfig.adminUsers.
+// Displays aggregate usage counts only; no per-user or per-board details.
+
+export const meta = () => [{ title: "Admin Dashboard – Retrograde" }];
+
+import { useLoaderData } from "react-router";
+import { requireRegisteredUser } from "~/hooks/useAuth";
+import { pool } from "~/server/db_config";
+import { siteConfig } from "~/config/siteConfig";
+import { getMetrics, type MetricsDTO } from "~/server/metrics_model";
+
+export async function loader({ request }: { request: Request }) {
+  const user = await requireRegisteredUser(request);
+
+  const userRow = await pool.query(
+    "SELECT external_id FROM users WHERE id = $1",
+    [user.id]
+  );
+  const externalId: string | undefined = userRow.rows[0]?.external_id;
+
+  if (!externalId || !siteConfig.adminUsers.includes(externalId)) {
+    throw new Response("Forbidden", { status: 403 });
+  }
+
+  const metrics = await getMetrics();
+  return { metrics };
+}
+
+interface StatCardProps {
+  label: string;
+  value: number;
+  description: string;
+}
+
+function StatCard({ label, value, description }: StatCardProps) {
+  return (
+    <div className="border rounded-lg p-6 flex flex-col gap-2 bg-white dark:bg-gray-900">
+      <div className="text-4xl font-bold text-blue-600 dark:text-blue-400">
+        {value.toLocaleString()}
+      </div>
+      <div className="text-lg font-semibold">{label}</div>
+      <div className="text-sm text-gray-500 dark:text-gray-400">{description}</div>
+    </div>
+  );
+}
+
+export default function AdminDashboard() {
+  const { metrics } = useLoaderData<typeof loader>() as { metrics: MetricsDTO };
+
+  return (
+    <div className="px-8 mx-auto w-full sm:w-[80%]">
+      <h1 className="text-3xl font-semibold mb-2">Admin Dashboard</h1>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-8">
+        Aggregate usage metrics — no personally identifiable information is displayed.
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-10">
+        <StatCard
+          label="Registered Users"
+          value={metrics.registeredUsers}
+          description="Non-anonymous accounts created via OAuth."
+        />
+        <StatCard
+          label="Notes Created"
+          value={metrics.totalNotes}
+          description="Total sticky notes across all boards."
+        />
+        <StatCard
+          label="Active Boards"
+          value={metrics.activeBoards}
+          description="Boards with real usage: a second contributor added a note, or the owner created 5 or more notes."
+        />
+        <StatCard
+          label="Engaged Users"
+          value={metrics.engagedUsers}
+          description="Registered users who are members of at least one active board."
+        />
+      </div>
+
+      <p className="text-xs text-gray-400 dark:text-gray-600">
+        Data reflects the current state of the database.
+      </p>
+    </div>
+  );
+}

--- a/app/server/admin_model.test.ts
+++ b/app/server/admin_model.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPoolQuery = vi.fn();
+vi.mock("~/server/db_config", () => ({
+  pool: { query: (...args: unknown[]) => mockPoolQuery(...args) },
+  siteAdminIds: [],
+}));
+
+vi.mock("~/server/db_init", () => ({}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+});
+
+describe("isGrantedAdmin", () => {
+  it("returns true when user_id is in admin_users", async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [{ "?column?": 1 }], rowCount: 1 });
+
+    const { isGrantedAdmin } = await import("./admin_model");
+    expect(await isGrantedAdmin("user-1")).toBe(true);
+    expect(mockPoolQuery).toHaveBeenCalledWith(
+      expect.stringContaining("admin_users"),
+      ["user-1"]
+    );
+  });
+
+  it("returns false when user_id is not in admin_users", async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const { isGrantedAdmin } = await import("./admin_model");
+    expect(await isGrantedAdmin("user-2")).toBe(false);
+  });
+});
+
+describe("listGrantedAdmins", () => {
+  it("returns formatted admin rows", async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [
+        { id: "au-1", userId: "u-1", username: "alice", grantedBy: "ext-root", createdAt: "2025-01-01T00:00:00Z" },
+        { id: "au-2", userId: "u-2", username: "bob",   grantedBy: "ext-root", createdAt: "2025-02-01T00:00:00Z" },
+      ],
+      rowCount: 2,
+    });
+
+    const { listGrantedAdmins } = await import("./admin_model");
+    const result = await listGrantedAdmins();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].username).toBe("alice");
+    expect(result[1].username).toBe("bob");
+  });
+
+  it("returns empty array when no granted admins exist", async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const { listGrantedAdmins } = await import("./admin_model");
+    expect(await listGrantedAdmins()).toEqual([]);
+  });
+});
+
+describe("findRegisteredUserByUsername", () => {
+  it("returns the user when found", async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ id: "u-1", username: "alice" }],
+      rowCount: 1,
+    });
+
+    const { findRegisteredUserByUsername } = await import("./admin_model");
+    const result = await findRegisteredUserByUsername("alice");
+
+    expect(result).toEqual({ id: "u-1", username: "alice" });
+    expect(mockPoolQuery).toHaveBeenCalledWith(
+      expect.stringContaining("is_anonymous = FALSE"),
+      ["alice"]
+    );
+  });
+
+  it("returns null when no user is found", async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const { findRegisteredUserByUsername } = await import("./admin_model");
+    expect(await findRegisteredUserByUsername("unknown")).toBeNull();
+  });
+});
+
+describe("addGrantedAdmin", () => {
+  it("inserts with ON CONFLICT DO NOTHING", async () => {
+    const { addGrantedAdmin } = await import("./admin_model");
+    await addGrantedAdmin("u-1", "ext-root");
+
+    expect(mockPoolQuery).toHaveBeenCalledWith(
+      expect.stringContaining("ON CONFLICT (user_id) DO NOTHING"),
+      ["u-1", "ext-root"]
+    );
+  });
+});
+
+describe("removeGrantedAdmin", () => {
+  it("deletes the row for the given userId", async () => {
+    const { removeGrantedAdmin } = await import("./admin_model");
+    await removeGrantedAdmin("u-1");
+
+    expect(mockPoolQuery).toHaveBeenCalledWith(
+      expect.stringContaining("DELETE FROM admin_users"),
+      ["u-1"]
+    );
+  });
+});

--- a/app/server/admin_model.ts
+++ b/app/server/admin_model.ts
@@ -1,0 +1,66 @@
+// app/server/admin_model.ts
+// Database operations for admin user management.
+// "Site admins" are set via SITE_ADMIN_IDS in the environment and always have
+// access. "Granted admins" are stored in the admin_users table and can be
+// added or removed by site admins through the UI.
+
+import { pool } from "./db_config";
+
+export interface GrantedAdmin {
+  id: string;
+  userId: string;
+  username: string;
+  grantedBy: string;
+  createdAt: string;
+}
+
+export async function isGrantedAdmin(userId: string): Promise<boolean> {
+  const result = await pool.query(
+    "SELECT 1 FROM admin_users WHERE user_id = $1",
+    [userId]
+  );
+  return (result.rowCount ?? 0) > 0;
+}
+
+export async function listGrantedAdmins(): Promise<GrantedAdmin[]> {
+  const result = await pool.query(`
+    SELECT
+      au.id,
+      au.user_id                                                            AS "userId",
+      u.preferred_username                                                  AS username,
+      au.granted_by                                                         AS "grantedBy",
+      to_char(au.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS "createdAt"
+    FROM admin_users au
+    JOIN users u ON u.id = au.user_id
+    ORDER BY au.created_at ASC
+  `);
+  return result.rows;
+}
+
+export async function findRegisteredUserByUsername(
+  username: string
+): Promise<{ id: string; username: string } | null> {
+  const result = await pool.query(
+    `SELECT id, preferred_username AS username
+     FROM users
+     WHERE preferred_username = $1 AND is_anonymous = FALSE`,
+    [username]
+  );
+  return result.rows[0] ?? null;
+}
+
+export async function addGrantedAdmin(
+  userId: string,
+  grantedByExternalId: string
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO admin_users (user_id, granted_by)
+     VALUES ($1, $2)
+     ON CONFLICT (user_id) DO NOTHING`,
+    [userId, grantedByExternalId]
+  );
+}
+
+export async function removeGrantedAdmin(userId: string): Promise<void> {
+  await pool.query("DELETE FROM admin_users WHERE user_id = $1", [userId]);
+}

--- a/app/server/db_config.ts
+++ b/app/server/db_config.ts
@@ -58,3 +58,16 @@ const enableSSL = process.env.NODE_ENV !== "development";
 const dropplet: { connectionString: string; ssl?: object } = { connectionString }
 
 export const pool = new Pool(dropplet);
+
+// Site admin IDs — external_id values (from the OAuth provider) that always
+// have access to the admin dashboard and can manage other admins.
+// Set via SITE_ADMIN_IDS in your environment (comma-separated).
+const rawSiteAdminIds = process.env.SITE_ADMIN_IDS ?? "";
+export const siteAdminIds: string[] = rawSiteAdminIds
+  .split(",")
+  .map((id) => id.trim())
+  .filter(Boolean);
+
+if (siteAdminIds.length === 0) {
+  console.warn("Warning: SITE_ADMIN_IDS is not set — the admin dashboard will be inaccessible.");
+}

--- a/app/server/db_init.ts
+++ b/app/server/db_init.ts
@@ -222,6 +222,18 @@ export async function initializeDatabase() {
       ADD COLUMN IF NOT EXISTS archived_at TIMESTAMP WITH TIME ZONE NULL;
     `);
 
+    // 16 Admin users — dynamically granted admin dashboard access
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS admin_users (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        granted_by TEXT NOT NULL,
+        created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+        UNIQUE(user_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_admin_users_user_id ON admin_users(user_id);
+    `);
+
     console.log("Done");
     console.log("Inserting dev data...");
 

--- a/app/server/metrics_model.test.ts
+++ b/app/server/metrics_model.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPoolQuery = vi.fn();
+vi.mock("~/server/db_config", () => ({
+  pool: { query: (...args: unknown[]) => mockPoolQuery(...args) },
+}));
+
+vi.mock("~/server/db_init", () => ({}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getMetrics", () => {
+  it("returns all four counts from the database", async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{
+        registeredUsers: 42,
+        totalNotes: 300,
+        activeBoards: 15,
+        engagedUsers: 28,
+      }],
+    });
+
+    const { getMetrics } = await import("./metrics_model");
+    const result = await getMetrics();
+
+    expect(result).toEqual({
+      registeredUsers: 42,
+      totalNotes: 300,
+      activeBoards: 15,
+      engagedUsers: 28,
+    });
+  });
+
+  it("issues a single query using the active_boards CTE", async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ registeredUsers: 0, totalNotes: 0, activeBoards: 0, engagedUsers: 0 }],
+    });
+
+    const { getMetrics } = await import("./metrics_model");
+    await getMetrics();
+
+    expect(mockPoolQuery).toHaveBeenCalledTimes(1);
+    const [sql] = mockPoolQuery.mock.calls[0] as [string];
+    expect(sql).toContain("active_boards");
+    expect(sql).toContain("registeredUsers");
+    expect(sql).toContain("totalNotes");
+    expect(sql).toContain("activeBoards");
+    expect(sql).toContain("engagedUsers");
+  });
+
+  it("active boards CTE requires board owner to be set", async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ registeredUsers: 0, totalNotes: 0, activeBoards: 0, engagedUsers: 0 }],
+    });
+
+    const { getMetrics } = await import("./metrics_model");
+    await getMetrics();
+
+    const [sql] = mockPoolQuery.mock.calls[0] as [string];
+    expect(sql).toContain("created_by IS NOT NULL");
+  });
+
+  it("active boards CTE counts 5+ owner notes as the threshold", async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ registeredUsers: 0, totalNotes: 0, activeBoards: 0, engagedUsers: 0 }],
+    });
+
+    const { getMetrics } = await import("./metrics_model");
+    await getMetrics();
+
+    const [sql] = mockPoolQuery.mock.calls[0] as [string];
+    expect(sql).toContain(">= 5");
+  });
+
+  it("returns zeros when the database is empty", async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ registeredUsers: 0, totalNotes: 0, activeBoards: 0, engagedUsers: 0 }],
+    });
+
+    const { getMetrics } = await import("./metrics_model");
+    const result = await getMetrics();
+
+    expect(result.registeredUsers).toBe(0);
+    expect(result.totalNotes).toBe(0);
+    expect(result.activeBoards).toBe(0);
+    expect(result.engagedUsers).toBe(0);
+  });
+});

--- a/app/server/metrics_model.ts
+++ b/app/server/metrics_model.ts
@@ -1,0 +1,61 @@
+// app/server/metrics_model.ts
+// Aggregate metrics queries for the admin dashboard.
+// Returns counts only — no PII, no per-user data.
+
+import { pool } from "./db_config";
+
+export interface MetricsDTO {
+  registeredUsers: number; // non-anonymous accounts
+  totalNotes: number;      // all notes in the database
+  activeBoards: number;    // boards with real usage (see definition below)
+  engagedUsers: number;    // registered users who are members of active boards
+}
+
+// A board is considered "active" (used beyond a quick test) when either:
+//   - At least one note was created by someone other than the board owner, OR
+//   - The board owner has created 5 or more notes on the board themselves.
+const ACTIVE_BOARDS_CTE = `
+  active_boards AS (
+    SELECT b.id
+    FROM boards b
+    WHERE b.created_by IS NOT NULL
+      AND (
+        EXISTS (
+          SELECT 1
+          FROM notes n
+          JOIN columns c ON n.column_id = c.id
+          WHERE c.board_id = b.id
+            AND n.created_by IS NOT NULL
+            AND n.created_by != b.created_by
+        )
+        OR (
+          SELECT COUNT(*)
+          FROM notes n
+          JOIN columns c ON n.column_id = c.id
+          WHERE c.board_id = b.id
+            AND n.created_by = b.created_by
+        ) >= 5
+      )
+  )
+`;
+
+export async function getMetrics(): Promise<MetricsDTO> {
+  const result = await pool.query(`
+    WITH ${ACTIVE_BOARDS_CTE}
+    SELECT
+      (SELECT COUNT(*) FROM users   WHERE is_anonymous = FALSE)::int  AS "registeredUsers",
+      (SELECT COUNT(*) FROM notes)::int                               AS "totalNotes",
+      (SELECT COUNT(*) FROM active_boards)::int                       AS "activeBoards",
+      (
+        SELECT COUNT(DISTINCT u.id)
+        FROM users u
+        JOIN board_members bm ON bm.user_id = u.id
+        WHERE u.is_anonymous = FALSE
+          AND EXISTS (
+            SELECT 1 FROM active_boards ab WHERE ab.id = bm.board_id
+          )
+      )::int                                                          AS "engagedUsers"
+  `);
+
+  return result.rows[0];
+}


### PR DESCRIPTION
## Summary

- Adds `/app/admin/dashboard` showing aggregate app usage metrics (registered users, total notes, active boards, engaged users)
- Implements a two-tier admin access system: **site admins** set via `SITE_ADMIN_IDS` env var (server-only, never bundled to client) and **granted admins** stored in the `admin_users` DB table
- Site admins see a **Manage Admins** section to grant/revoke access for other registered users without code changes or redeployment

## Access control

| Tier | How set | Can be locked out? | Can manage admins? |
|---|---|---|---|
| Site admin | `SITE_ADMIN_IDS` env var | No | Yes |
| Granted admin | `admin_users` DB table via UI | Yes (removable) | No |

Set yourself up in `.env`:
```
SITE_ADMIN_IDS=your-external-id-from-oauth-provider
```

## Changes

- `app/server/db_config.ts` — parse `SITE_ADMIN_IDS` into `siteAdminIds[]` at startup
- `app/config/siteConfig.ts` — remove `adminUsers` (was incorrectly client-bundle-visible)
- `app/server/db_init.ts` — add `admin_users` table (migration #16)
- `app/server/admin_model.ts` — DB operations for admin management
- `app/routes/app/admin.admins.ts` — POST resource route for add/remove (site admins only)
- `app/routes/app/admin.dashboard.tsx` — metrics page + Manage Admins UI
- `app/routes.ts` — register new routes

## Test plan

- [ ] Set `SITE_ADMIN_IDS` to your OAuth `external_id` and visit `/app/admin/dashboard`
- [ ] Confirm metrics display correctly
- [ ] Confirm Manage Admins section is visible only to site admins
- [ ] Grant access to another registered user and verify they can reach the dashboard
- [ ] Remove a granted admin and verify they get 403
- [ ] Confirm a non-admin registered user receives 403
- [ ] Confirm unauthenticated users are redirected to login

https://claude.ai/code/session_01P753RufqR196ZwQwRkFh8V