### PR TITLE
Feature/admin dashboard link

### DIFF
--- a/app/components/AccountHub.test.tsx
+++ b/app/components/AccountHub.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+
+vi.mock("~/hooks/useTheme", () => ({
+  useTheme: () => ({
+    theme: "system",
+    resolvedTheme: "light",
+    setTheme: vi.fn(),
+  }),
+}));
+
+vi.mock("~/config/siteConfig", () => ({
+  siteConfig: { dashboardHome: false },
+}));
+
+import AccountHub from "./AccountHub";
+
+const user = { id: "user-1", username: "testuser" };
+
+describe("AccountHub", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows admin dashboard link when isAdmin is true", () => {
+    render(<AccountHub user={user} isAdmin={true} />);
+    // Open the dropdown
+    fireEvent.click(screen.getByText("testuser"));
+    expect(screen.getByText("Admin Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Admin Dashboard").closest("a")).toHaveAttribute(
+      "href",
+      "/app/admin/dashboard"
+    );
+  });
+
+  it("does not show admin dashboard link when isAdmin is false", () => {
+    render(<AccountHub user={user} isAdmin={false} />);
+    fireEvent.click(screen.getByText("testuser"));
+    expect(screen.queryByText("Admin Dashboard")).not.toBeInTheDocument();
+  });
+
+  it("does not show admin dashboard link when isAdmin is not provided", () => {
+    render(<AccountHub user={user} />);
+    fireEvent.click(screen.getByText("testuser"));
+    expect(screen.queryByText("Admin Dashboard")).not.toBeInTheDocument();
+  });
+
+  it("shows dashboard link regardless of admin status", () => {
+    render(<AccountHub user={user} isAdmin={false} />);
+    fireEvent.click(screen.getByText("testuser"));
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+  });
+});

--- a/app/components/AccountHub.tsx
+++ b/app/components/AccountHub.tsx
@@ -9,10 +9,11 @@ interface AccountHubProps {
     id: string;
     username: string;
   };
+  isAdmin?: boolean;
   closeMenu?: () => void;
 }
 
-export default function AccountHub({ user, closeMenu }: AccountHubProps) {
+export default function AccountHub({ user, isAdmin, closeMenu }: AccountHubProps) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -92,6 +93,16 @@ export default function AccountHub({ user, closeMenu }: AccountHubProps) {
             className="w-full justify-start"
             onClick={() => setOpen(false)}
           />
+          {isAdmin && (
+            <Button
+              as="a"
+              href="/app/admin/dashboard"
+              variant="text"
+              text="Admin Dashboard"
+              className="w-full justify-start"
+              onClick={() => setOpen(false)}
+            />
+          )}
           <div className="inline-flex justify-between items-center w-full px-4 py-2">
             <div className="text-sm font-semibold mr-1">
               Theme

--- a/app/components/AppLayout.tsx
+++ b/app/components/AppLayout.tsx
@@ -4,20 +4,31 @@
 import { useLoaderData, Outlet } from "react-router";
 import { requireRegisteredUser } from "~/hooks/useAuth";
 import { UserProvider } from "~/context/userContext";
+import { pool, siteAdminIds } from "~/server/db_config";
+import { isGrantedAdmin } from "~/server/admin_model";
 import Header from "./Header";
 
 export async function loader({ request }: { request: Request }) {
   const user = await requireRegisteredUser(request);
-  return { user };
+
+  const userRow = await pool.query(
+    "SELECT external_id FROM users WHERE id = $1",
+    [user.id]
+  );
+  const externalId: string | undefined = userRow.rows[0]?.external_id;
+  const isSiteAdmin = Boolean(externalId && siteAdminIds.includes(externalId));
+  const isAdmin = isSiteAdmin || await isGrantedAdmin(user.id);
+
+  return { user, isAdmin };
 }
 
 export default function AppLayout() {
-  const { user } = useLoaderData();
+  const { user, isAdmin } = useLoaderData();
 
   return (
     <UserProvider user={user}>
       <div className='min-h-screen flex flex-col'>
-        <Header user={user} />
+        <Header user={user} isAdmin={isAdmin} />
         <Outlet />
       </div>
     </UserProvider>

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -9,9 +9,10 @@ interface HeaderProps {
     id: string;
     username: string;
   };
+  isAdmin?: boolean;
 }
 
-export default function Header({ user }: HeaderProps) {
+export default function Header({ user, isAdmin }: HeaderProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -99,7 +100,7 @@ export default function Header({ user }: HeaderProps) {
         <a href="/contact" className="hover:underline">
           Contact
         </a>
-        <AccountHub user={user} />
+        <AccountHub user={user} isAdmin={isAdmin} />
       </nav>
 
       {/* Hamburger */}

--- a/app/server/db_config.ts
+++ b/app/server/db_config.ts
@@ -55,7 +55,10 @@ console.log(maskedConnectionString(connectionString));
 console.log("NODE_ENV", process.env.NODE_ENV);
 const enableSSL = process.env.NODE_ENV !== "development";
 
-const dropplet: { connectionString: string; ssl?: object } = { connectionString }
+const dropplet: { connectionString: string; ssl?: object } = { connectionString };
+if (enableSSL) {
+  dropplet.ssl = { rejectUnauthorized: false };
+}
 
 export const pool = new Pool(dropplet);
 


### PR DESCRIPTION
## Summary
   - AppLayout loader checks if the user is a site admin (`SITE_ADMIN_IDS` env var) or granted admin (`admin_users` table) and passes `isAdmin` down through Header to AccountHub
   - AccountHub conditionally renders an "Admin Dashboard" link in the dropdown menu for admin users
   - Added AccountHub tests covering admin link visibility
   - Fixed production DB connection — `enableSSL` was computed but never applied to the pool config, causing auth timeouts on Vercel

   ## Test plan
   - [x] All 189 tests pass including 4 new AccountHub tests
   - [x] Log in as a site admin (external_id in `SITE_ADMIN_IDS`) and verify "Admin Dashboard" link appears
   - [x] Log in as a granted admin and verify link appears
   - [x] Log in as a regular user and verify link does not appear
   - [x] Verify Vercel deployment connects to DB without timeout