### PR TITLE
Gate VERCEL_URL OAuth redirect on preview env only

### DIFF
--- a/app/server/db_config.test.ts
+++ b/app/server/db_config.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("pg", () => ({
+  Pool: class {},
+}));
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  vi.resetModules();
+  process.env = { ...originalEnv };
+  process.env.DATABASE_URL = "postgresql://user:pass@host/db";
+  delete process.env.VERCEL_URL;
+  delete process.env.VERCEL_ENV;
+  delete process.env.OAUTH_REDIRECT_URI;
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+describe("oauthRedirectUri", () => {
+  it("uses OAUTH_REDIRECT_URI in local dev (no VERCEL_ENV)", async () => {
+    process.env.OAUTH_REDIRECT_URI = "http://localhost:3000/auth/callback";
+    const { oauthRedirectUri } = await import("./db_config");
+    expect(oauthRedirectUri).toBe("http://localhost:3000/auth/callback");
+  });
+
+  it("uses VERCEL_URL when VERCEL_ENV is preview", async () => {
+    process.env.VERCEL_ENV = "preview";
+    process.env.VERCEL_URL = "retrograde-abc123.vercel.app";
+    process.env.OAUTH_REDIRECT_URI = "https://retrograde.example.com/auth/callback";
+    const { oauthRedirectUri } = await import("./db_config");
+    expect(oauthRedirectUri).toBe("https://retrograde-abc123.vercel.app/auth/callback");
+  });
+
+  it("uses OAUTH_REDIRECT_URI in production even when VERCEL_URL is set", async () => {
+    process.env.VERCEL_ENV = "production";
+    process.env.VERCEL_URL = "retrograde-prod.vercel.app";
+    process.env.OAUTH_REDIRECT_URI = "https://retrograde.example.com/auth/callback";
+    const { oauthRedirectUri } = await import("./db_config");
+    expect(oauthRedirectUri).toBe("https://retrograde.example.com/auth/callback");
+  });
+
+  it("falls back to OAUTH_REDIRECT_URI in preview when VERCEL_URL missing", async () => {
+    process.env.VERCEL_ENV = "preview";
+    process.env.OAUTH_REDIRECT_URI = "https://retrograde.example.com/auth/callback";
+    const { oauthRedirectUri } = await import("./db_config");
+    expect(oauthRedirectUri).toBe("https://retrograde.example.com/auth/callback");
+  });
+});

--- a/app/server/db_config.ts
+++ b/app/server/db_config.ts
@@ -72,8 +72,10 @@ if (siteAdminIds.length === 0) {
   console.warn("Warning: SITE_ADMIN_IDS is not set — the admin dashboard will be inaccessible.");
 }
 
-// OAuth redirect URI — use VERCEL_URL for preview deployments, fall back to
-// the explicit OAUTH_REDIRECT_URI for local dev and production.
-export const oauthRedirectUri = process.env.VERCEL_URL
-  ? `https://${process.env.VERCEL_URL}/auth/callback`
-  : process.env.OAUTH_REDIRECT_URI!;
+// OAuth redirect URI — use VERCEL_URL only in preview deployments (where each
+// deploy gets a unique hostname). Production also has VERCEL_URL set, but we
+// want the stable OAUTH_REDIRECT_URI there. Local dev also uses OAUTH_REDIRECT_URI.
+export const oauthRedirectUri =
+  process.env.VERCEL_ENV === "preview" && process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}/auth/callback`
+    : process.env.OAUTH_REDIRECT_URI!;


### PR DESCRIPTION
## Summary
- Production Vercel deployments also set `VERCEL_URL`, so the previous check was redirecting OAuth to the Vercel-assigned hostname in prod instead of the stable `OAUTH_REDIRECT_URI`.
- Require `VERCEL_ENV === "preview"` before using `VERCEL_URL`; prod and local dev now fall through to `OAUTH_REDIRECT_URI`.
- Added `db_config.test.ts` covering local dev, preview, production-with-VERCEL_URL, and preview-without-VERCEL_URL.

## Test plan
- [x] `npx vitest run app/server/db_config.test.ts` — 4/4 pass
- [x] Verify a preview deploy still redirects to its `*.vercel.app` hostname
- [x] Verify production deploy redirects to the configured `OAUTH_REDIRECT_URI`

🤖 Generated with [Claude Code](https://claude.com/claude-code)